### PR TITLE
Updated submitted returns view to use new tab content

### DIFF
--- a/app/controllers/ReturnObligationsController.scala
+++ b/app/controllers/ReturnObligationsController.scala
@@ -20,8 +20,8 @@ import java.time.LocalDate
 import javax.inject.Inject
 
 import config.AppConfig
-import models.viewModels.ReturnDeadline
-import models.{User, VatReturnObligations}
+import models.viewModels.{ReturnDeadline, ReturnObligationsViewModel, VatReturnsViewModel}
+import models.User
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent}
 import services.{EnrolmentsAuthService, ReturnsService}
@@ -38,8 +38,8 @@ class ReturnObligationsController @Inject()(val messagesApi: MessagesApi,
   def completedReturns(year: Int): Action[AnyContent] = authorisedAction { implicit request =>
     implicit user =>
       if(validateSearchYear(year)) {
-        getReturnObligations(user, year).map { returnObligations =>
-          Ok(views.html.returns.completedReturns(returnObligations, Seq(2018, 2017, 2016, 2015), year))
+        getReturnObligations(user, year).map { model =>
+          Ok(views.html.returns.completedReturns(model))
         }
       } else {
         Future.successful(NotFound(views.html.errors.notFound()))
@@ -59,10 +59,23 @@ class ReturnObligationsController @Inject()(val messagesApi: MessagesApi,
     year <= upperBound && year >= upperBound - 3
   }
 
-  private[controllers] def getReturnObligations(user: User, year: Int)(implicit hc: HeaderCarrier): Future[VatReturnObligations] = {
+  private[controllers] def getReturnObligations(user: User, year: Int)(implicit hc: HeaderCarrier): Future[VatReturnsViewModel] = {
+    val currentYear: Int = LocalDate.now().getYear
+    val yearsToDisplay: Seq[Int] = (currentYear to currentYear - 3) by -1
+
     returnsService.getReturnObligationsForYear(user, year).map {
-      case Right(vatReturnObligations) => vatReturnObligations
-      case Left(_) => VatReturnObligations(Seq())
+      case Right(obligations) => VatReturnsViewModel(
+        yearsToDisplay,
+        year,
+        obligations.obligations.map( obligation =>
+          ReturnObligationsViewModel(
+            obligation.start,
+            obligation.end,
+            obligation.periodKey
+          )
+        )
+      )
+      case Left(_) => VatReturnsViewModel(yearsToDisplay, year, Seq())
     }
   }
 }

--- a/app/controllers/ReturnObligationsController.scala
+++ b/app/controllers/ReturnObligationsController.scala
@@ -39,7 +39,7 @@ class ReturnObligationsController @Inject()(val messagesApi: MessagesApi,
     implicit user =>
       if(validateSearchYear(year)) {
         getReturnObligations(user, year).map { returnObligations =>
-          Ok(views.html.returns.completedReturns(returnObligations, Seq(2018, 2017, 2016, 2015), 2016))
+          Ok(views.html.returns.completedReturns(returnObligations, Seq(2018, 2017, 2016, 2015), year))
         }
       } else {
         Future.successful(NotFound(views.html.errors.notFound()))

--- a/app/controllers/ReturnObligationsController.scala
+++ b/app/controllers/ReturnObligationsController.scala
@@ -59,14 +59,14 @@ class ReturnObligationsController @Inject()(val messagesApi: MessagesApi,
     year <= upperBound && year >= upperBound - 3
   }
 
-  private[controllers] def getReturnObligations(user: User, year: Int)(implicit hc: HeaderCarrier): Future[VatReturnsViewModel] = {
+  private[controllers] def getReturnObligations(user: User, selectedYear: Int)(implicit hc: HeaderCarrier): Future[VatReturnsViewModel] = {
     val currentYear: Int = LocalDate.now().getYear
-    val yearsToDisplay: Seq[Int] = (currentYear to currentYear - 3) by -1
+    val returnYears: Seq[Int] = (currentYear to currentYear - 3) by -1
 
-    returnsService.getReturnObligationsForYear(user, year).map {
+    returnsService.getReturnObligationsForYear(user, selectedYear).map {
       case Right(obligations) => VatReturnsViewModel(
-        yearsToDisplay,
-        year,
+        returnYears,
+        selectedYear,
         obligations.obligations.map( obligation =>
           ReturnObligationsViewModel(
             obligation.start,
@@ -75,7 +75,7 @@ class ReturnObligationsController @Inject()(val messagesApi: MessagesApi,
           )
         )
       )
-      case Left(_) => VatReturnsViewModel(yearsToDisplay, year, Seq())
+      case Left(_) => VatReturnsViewModel(returnYears, selectedYear, Seq())
     }
   }
 }

--- a/app/controllers/ReturnObligationsController.scala
+++ b/app/controllers/ReturnObligationsController.scala
@@ -39,7 +39,7 @@ class ReturnObligationsController @Inject()(val messagesApi: MessagesApi,
     implicit user =>
       if(validateSearchYear(year)) {
         getReturnObligations(user, year).map { returnObligations =>
-          Ok(views.html.returns.completedReturns(returnObligations))
+          Ok(views.html.returns.completedReturns(returnObligations, Seq(2018, 2017, 2016, 2015), 2016))
         }
       } else {
         Future.successful(NotFound(views.html.errors.notFound()))

--- a/app/controllers/ReturnsController.scala
+++ b/app/controllers/ReturnsController.scala
@@ -35,7 +35,7 @@ class ReturnsController @Inject()(val messagesApi: MessagesApi,
                                   implicit val appConfig: AppConfig)
   extends AuthorisedController {
 
-  def vatReturnDetails(start: String, end: String): Action[AnyContent] = authorisedAction {
+  def vatReturnDetails(start: String, end: String, periodKey: String = ""): Action[AnyContent] = authorisedAction {
     implicit request =>
       implicit user =>
         val vatReturnCall = returnsService.getVatReturnDetails(user, LocalDate.parse(start), LocalDate.parse(end))

--- a/app/controllers/ReturnsController.scala
+++ b/app/controllers/ReturnsController.scala
@@ -35,7 +35,7 @@ class ReturnsController @Inject()(val messagesApi: MessagesApi,
                                   implicit val appConfig: AppConfig)
   extends AuthorisedController {
 
-  def vatReturnDetails(start: String, end: String, periodKey: String = ""): Action[AnyContent] = authorisedAction {
+  def vatReturnDetails(start: String, end: String): Action[AnyContent] = authorisedAction {
     implicit request =>
       implicit user =>
         val vatReturnCall = returnsService.getVatReturnDetails(user, LocalDate.parse(start), LocalDate.parse(end))

--- a/app/models/viewModels/ReturnObligationsViewModel.scala
+++ b/app/models/viewModels/ReturnObligationsViewModel.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.viewModels
+
+import java.time.LocalDate
+
+case class ReturnObligationsViewModel(start: LocalDate,
+                                      end: LocalDate,
+                                      periodKey: String)

--- a/app/models/viewModels/VatReturnsViewModel.scala
+++ b/app/models/viewModels/VatReturnsViewModel.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.viewModels
+
+case class VatReturnsViewModel(yearsToDisplay: Seq[Int],
+                               selectedYear: Int,
+                               obligations: Seq[ReturnObligationsViewModel])

--- a/app/models/viewModels/VatReturnsViewModel.scala
+++ b/app/models/viewModels/VatReturnsViewModel.scala
@@ -16,6 +16,6 @@
 
 package models.viewModels
 
-case class VatReturnsViewModel(yearsToDisplay: Seq[Int],
+case class VatReturnsViewModel(returnYears: Seq[Int],
                                selectedYear: Int,
                                obligations: Seq[ReturnObligationsViewModel])

--- a/app/views/returns/completedReturns.scala.html
+++ b/app/views/returns/completedReturns.scala.html
@@ -15,8 +15,9 @@
  *@
 
 @import views.html.templates.formatters.dates._
+@import models.viewModels._
 
-@(returns: VatReturnObligations, obligationYears: Seq[Int], selectedYear: Int)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(model: VatReturnsViewModel)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @views.html.main_template(title = messages("completedReturns.title"), bodyClasses = None, appConfig = appConfig) {
 
@@ -28,9 +29,9 @@
 
         <ul class="tabs-nav">
 
-          @for(yearToDisplay <- obligationYears) {
+          @for(yearToDisplay <- model.yearsToDisplay) {
 
-            @if(yearToDisplay == selectedYear) {
+            @if(yearToDisplay == model.selectedYear) {
 
               <li class="tabs-nav__tab tabs-nav__tab--active font-medium">
                 @yearToDisplay
@@ -52,9 +53,9 @@
 
         <section class="divider--bottom">
 
-          <h2>@messages("completedReturns.yearReturns", selectedYear.toString())</h2>
+          <h2>@messages("completedReturns.yearReturns", model.selectedYear.toString())</h2>
 
-          @if(returns.obligations.isEmpty) {
+          @if(model.obligations.isEmpty) {
             <!--TODO: update with content from design team-->
             <p>Alternate Content</p>
           } else {
@@ -63,7 +64,7 @@
 
             <ul class="list list-bullet">
 
-              @for(obligation <- returns.obligations) {
+              @for(obligation <- model.obligations) {
 
                 <li>
                     <!--TODO: update to pass period key instead of date range-->

--- a/app/views/returns/completedReturns.scala.html
+++ b/app/views/returns/completedReturns.scala.html
@@ -18,13 +18,15 @@
 
 @(returns: VatReturnObligations, obligationYears: Seq[Int], selectedYear: Int)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
+@url = {controllers.routes.ReturnsController.vatReturnDetails("", "h", "h").url}
+
 @views.html.main_template(title = messages("completedReturns.title"), bodyClasses = None, appConfig = appConfig) {
 
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-xlarge">@messages("completedReturns.title")</h1>
 
-      <p>@messages("common.submitReturns")</p>
+      <p>@messages("completedReturns.submitMethod")</p>
 
         <ul class="tabs-nav">
 
@@ -39,7 +41,7 @@
             } else {
 
               <li class="tabs-nav__tab font-medium">
-                <a href="#">@year
+                <a href="@controllers.routes.ReturnObligationsController.completedReturns(year).url">@year
                   <span class="visuallyhidden">@messages("completedReturns.inactiveTab", year.toString())</span>
                 </a>
               </li>
@@ -49,22 +51,25 @@
 
         <section class="divider--bottom">
 
-            <h2>@messages("completedReturns.yearReturns", selectedYear.toString())</h2>
+          <h2>@messages("completedReturns.yearReturns", selectedYear.toString())</h2>
 
-            @if(returns.obligations.isEmpty) {
-                <!--TODO: alternate content-->
-            } else {
+          @if(returns.obligations.isEmpty) {
+            <!--TODO: alternate content-->
+          } else {
 
-                <p>@messages("completedReturns.period")</p>
+            <p>@messages("completedReturns.period")</p>
 
-                <ul class="list list-bullet">
-                    @for(obligation <- returns.obligations) {
-                        <li><a href="#">@displayDateRange(obligation.start, obligation.end)</a></li>
-                    }
-
-                </ul>
-            }
-
+            <ul class="list list-bullet">
+              @for(obligation <- returns.obligations) {
+                <li>
+                    <!--TODO: update to pass period key instead of date range-->
+                    <a href="@controllers.routes.ReturnsController.vatReturnDetails(obligation.start.toString(), obligation.end.toString()).url">
+                        @displayDateRange(obligation.start, obligation.end)
+                    </a>
+                </li>
+              }
+            </ul>
+          }
         </section>
 
         <h3>@messages("completedReturns.otherReturnsHeading")</h3>
@@ -72,6 +77,7 @@
             @messages("completedReturns.otherReturnsOne")
             <a href="@appConfig.portalUrl">@messages("completedReturns.otherReturnsTwo")</a>
         </p>
+
     </div>
   </div>
 }

--- a/app/views/returns/completedReturns.scala.html
+++ b/app/views/returns/completedReturns.scala.html
@@ -29,7 +29,7 @@
 
         <ul class="tabs-nav">
 
-          @for(yearToDisplay <- model.yearsToDisplay) {
+          @for(yearToDisplay <- model.returnYears) {
 
             @if(yearToDisplay == model.selectedYear) {
 

--- a/app/views/returns/completedReturns.scala.html
+++ b/app/views/returns/completedReturns.scala.html
@@ -18,8 +18,6 @@
 
 @(returns: VatReturnObligations, obligationYears: Seq[Int], selectedYear: Int)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
-@url = {controllers.routes.ReturnsController.vatReturnDetails("", "h", "h").url}
-
 @views.html.main_template(title = messages("completedReturns.title"), bodyClasses = None, appConfig = appConfig) {
 
   <div class="grid-row">
@@ -30,23 +28,26 @@
 
         <ul class="tabs-nav">
 
-          @for(year <- obligationYears) {
+          @for(yearToDisplay <- obligationYears) {
 
-            @if(year == selectedYear) {
+            @if(yearToDisplay == selectedYear) {
 
               <li class="tabs-nav__tab tabs-nav__tab--active font-medium">
-                @year
-                <span class="visuallyhidden">@messages("completedReturns.activeTab", year.toString())</span>
+                @yearToDisplay
+                <span class="visuallyhidden">@messages("completedReturns.activeTab", yearToDisplay.toString())</span>
               </li>
+
             } else {
 
               <li class="tabs-nav__tab font-medium">
-                <a href="@controllers.routes.ReturnObligationsController.completedReturns(year).url">@year
-                  <span class="visuallyhidden">@messages("completedReturns.inactiveTab", year.toString())</span>
+                <a href="@controllers.routes.ReturnObligationsController.completedReturns(yearToDisplay).url">
+                  @yearToDisplay
+                  <span class="visuallyhidden">@messages("completedReturns.inactiveTab", yearToDisplay.toString())</span>
                 </a>
               </li>
             }
           }
+
         </ul>
 
         <section class="divider--bottom">
@@ -54,14 +55,16 @@
           <h2>@messages("completedReturns.yearReturns", selectedYear.toString())</h2>
 
           @if(returns.obligations.isEmpty) {
-            <!--TODO: alternate content-->
+            <!--TODO: update with content from design team-->
             <p>Alternate Content</p>
           } else {
 
             <p>@messages("completedReturns.period")</p>
 
             <ul class="list list-bullet">
+
               @for(obligation <- returns.obligations) {
+
                 <li>
                     <!--TODO: update to pass period key instead of date range-->
                     <a href="@controllers.routes.ReturnsController.vatReturnDetails(obligation.start.toString(), obligation.end.toString()).url">
@@ -69,8 +72,10 @@
                     </a>
                 </li>
               }
+
             </ul>
           }
+
         </section>
 
         <h3>@messages("completedReturns.otherReturnsHeading")</h3>

--- a/app/views/returns/completedReturns.scala.html
+++ b/app/views/returns/completedReturns.scala.html
@@ -55,6 +55,7 @@
 
           @if(returns.obligations.isEmpty) {
             <!--TODO: alternate content-->
+            <p>Alternate Content</p>
           } else {
 
             <p>@messages("completedReturns.period")</p>

--- a/app/views/returns/completedReturns.scala.html
+++ b/app/views/returns/completedReturns.scala.html
@@ -16,58 +16,62 @@
 
 @import views.html.templates.formatters.dates._
 
-@(returns: VatReturnObligations)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(returns: VatReturnObligations, obligationYears: Seq[Int], selectedYear: Int)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @views.html.main_template(title = messages("completedReturns.title"), bodyClasses = None, appConfig = appConfig) {
 
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-xlarge">@messages("completedReturns.title")</h1>
-      <p>@messages("completedReturns.submitMethod")</p>
-      @if(returns.obligations.isEmpty) {
-        <h2 class="heading-medium">@messages("completedReturns.noReturns")</h2>
-      } else {
-        <table id="completedReturns" class="form-group">
-          <caption class="visually-hidden">@messages("completedReturns.tableCaption")</caption>
-          <thead>
-            <tr>
-              <th>@messages("completedReturns.periodEnding")</th>
-              <th>@messages("completedReturns.status")</th>
-              <th>@messages("completedReturns.returnDetails")</th>
-            </tr>
-          </thead>
-          <tbody>
-            @returns.obligations.collect {
-              case obligation if obligation.status == "O" => {
-                <tr>
-                  <td>@displayDate(obligation.end)</td>
-                  <td>@messages("completedReturns.due") @displayDate(obligation.due)</td>
-                  <td>@messages("completedReturns.notSubmitted")</td>
-                </tr>
-              }
-            }
-            @returns.obligations.collect {
-              case obligation if obligation.status == "F" => {
-                <tr>
-                  <td>@displayDate(obligation.end)</td>
-                  <td>@messages("completedReturns.received")</td>
-                  <td>
-                    <a href="@controllers.routes.ReturnsController.vatReturnDetails(obligation.start.toString, obligation.end.toString)">
-                      @messages("completedReturns.viewReturnOne") @displayDate(obligation.end) @messages("completedReturns.viewReturnTwo")
-                    </a>
-                  </td>
-                </tr>
-              }
-            }
-          </tbody>
-        </table>
-      }
 
-      <p>@messages("completedReturns.viewEarlierReturnsOne")
-        <a href="@appConfig.portalUrl">@messages("completedReturns.viewEarlierReturnsTwo")</a>
-        @messages("completedReturns.viewEarlierReturnsThree")
-      </p>
+      <p>@messages("common.submitReturns")</p>
 
+        <ul class="tabs-nav">
+
+          @for(year <- obligationYears) {
+
+            @if(year == selectedYear) {
+
+              <li class="tabs-nav__tab tabs-nav__tab--active font-medium">
+                @year
+                <span class="visuallyhidden">@messages("completedReturns.activeTab", year.toString())</span>
+              </li>
+            } else {
+
+              <li class="tabs-nav__tab font-medium">
+                <a href="#">@year
+                  <span class="visuallyhidden">@messages("completedReturns.inactiveTab", year.toString())</span>
+                </a>
+              </li>
+            }
+          }
+        </ul>
+
+        <section class="divider--bottom">
+
+            <h2>@messages("completedReturns.yearReturns", selectedYear.toString())</h2>
+
+            @if(returns.obligations.isEmpty) {
+                <!--TODO: alternate content-->
+            } else {
+
+                <p>@messages("completedReturns.period")</p>
+
+                <ul class="list list-bullet">
+                    @for(obligation <- returns.obligations) {
+                        <li><a href="#">@displayDateRange(obligation.start, obligation.end)</a></li>
+                    }
+
+                </ul>
+            }
+
+        </section>
+
+        <h3>@messages("completedReturns.otherReturnsHeading")</h3>
+        <p>
+            @messages("completedReturns.otherReturnsOne")
+            <a href="@appConfig.portalUrl">@messages("completedReturns.otherReturnsTwo")</a>
+        </p>
     </div>
   </div>
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
 GET        /return                  controllers.ReturnsController.vatReturnDetails(start: String, end: String)
-GET        /returns                 controllers.ReturnObligationsController.completedReturns(year: Int)
+GET        /returns/:year           controllers.ReturnObligationsController.completedReturns(year: Int)
 GET        /return-deadlines        controllers.ReturnObligationsController.returnDeadlines
 GET        /feature-switch          controllers.FeatureSwitchController.featureSwitch
 POST       /feature-switch          controllers.FeatureSwitchController.submitFeatureSwitch

--- a/conf/messages
+++ b/conf/messages
@@ -50,16 +50,6 @@ completedReturns.period = For the period:
 completedReturns.otherReturnsHeading = Other returns
 completedReturns.otherReturnsOne = You can also
 completedReturns.otherReturnsTwo = view returns submitted before using accounting software (opens in new tab).
-
-completedReturns.due = Due
-completedReturns.received = Received
-completedReturns.viewReturnOne = View
-completedReturns.viewReturnTwo = Return
-completedReturns.viewEarlierReturnsOne = You can also
-completedReturns.viewEarlierReturnsTwo = view earlier returns
-completedReturns.viewEarlierReturnsThree = you submitted before using accounting software.
-completedReturns.noReturns = You have no returns.
-completedReturns.tableCaption = VAT returns found since opting in for Making Tax Digital For Business
 completedReturns.activeTab = Currently viewing returns from {0}
 completedReturns.inactiveTab = View returns from {0}
 

--- a/conf/messages
+++ b/conf/messages
@@ -44,11 +44,12 @@ yourVatReturn.adjustments = If there are any errors, you can make adjustments th
 yourVatReturn.paymentProcessed = Your payment has been processed. There is nothing more you need to do with this return.
 
 completedReturns.title = VAT returns
-completedReturns.submitMethod = You submit returns through your accounting software.
-completedReturns.periodEnding = Period ending
-completedReturns.status = Status
-completedReturns.returnDetails = Return details
-completedReturns.notSubmitted = Not yet submitted
+completedReturns.yearReturns = {0} Returns
+completedReturns.period = For the period:
+completedReturns.otherReturnsHeading = Other returns
+completedReturns.otherReturnsOne = You can also
+completedReturns.otherReturnsTwo = view returns submitted before using accounting software (opens in new tab).
+
 completedReturns.due = Due
 completedReturns.received = Received
 completedReturns.viewReturnOne = View
@@ -58,6 +59,8 @@ completedReturns.viewEarlierReturnsTwo = view earlier returns
 completedReturns.viewEarlierReturnsThree = you submitted before using accounting software.
 completedReturns.noReturns = You have no returns.
 completedReturns.tableCaption = VAT returns found since opting in for Making Tax Digital For Business
+completedReturns.activeTab = Currently viewing returns from {0}
+completedReturns.inactiveTab = View returns from {0}
 
 returnDeadlines.title = Return deadlines
 returnDeadlines.submitBy = You must use your accounting software to submit a return by:

--- a/conf/messages
+++ b/conf/messages
@@ -44,6 +44,7 @@ yourVatReturn.adjustments = If there are any errors, you can make adjustments th
 yourVatReturn.paymentProcessed = Your payment has been processed. There is nothing more you need to do with this return.
 
 completedReturns.title = VAT returns
+completedReturns.submitMethod = You submit returns through your accounting software.
 completedReturns.yearReturns = {0} Returns
 completedReturns.period = For the period:
 completedReturns.otherReturnsHeading = Other returns

--- a/it/pages/CompletedReturnsPageSpec.scala
+++ b/it/pages/CompletedReturnsPageSpec.scala
@@ -31,13 +31,13 @@ class CompletedReturnsPageSpec extends IntegrationBaseSpec {
 
     def request(): WSRequest = {
       setupStubs()
-      buildRequest("/returns?year=2017")
+      buildRequest("/returns/2017")
     }
   }
 
-  "Calling the returns route" when {
+  "Calling the returns route with an authenticated user with three obligation end dates in 2017 and one in 2018" when {
 
-    "the user is authenticated and has three 2017 obligations" should {
+    "calling the 2017 route" should {
 
       "return 200" in new Test {
         override def setupStubs(): StubMapping = {
@@ -58,9 +58,46 @@ class CompletedReturnsPageSpec extends IntegrationBaseSpec {
 
         lazy implicit val document: Document = Jsoup.parse(response.body)
 
-        val rowSelector = "#completedReturns tbody tr"
+        val bulletPointSelector = ".list-bullet li"
 
-        document.select(rowSelector).size() shouldBe 3
+        document.select(bulletPointSelector).size() shouldBe 3
+      }
+    }
+
+    "calling the 2018 route" should {
+
+      "return 200" in new Test {
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          VatApiStub.stubPrototypeObligations
+        }
+        override def request(): WSRequest = {
+          setupStubs()
+          buildRequest("/returns/2018")
+        }
+
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.OK
+      }
+
+      "return one obligation" in new Test {
+
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          VatApiStub.stubPrototypeObligations
+        }
+        override def request(): WSRequest = {
+          setupStubs()
+          buildRequest("/returns/2018")
+        }
+
+        val response: WSResponse = await(request().get())
+
+        lazy implicit val document: Document = Jsoup.parse(response.body)
+
+        val bulletPointSelector = ".list-bullet li"
+
+        document.select(bulletPointSelector).size() shouldBe 1
       }
     }
   }

--- a/test/app/RouteSpec.scala
+++ b/test/app/RouteSpec.scala
@@ -30,7 +30,7 @@ class RouteSpec extends UnitSpec with GuiceOneAppPerSuite {
 
   "The route for the list of returns" should {
     "be /view-your-vat-returns/returns" in {
-      controllers.routes.ReturnObligationsController.completedReturns(2017).url shouldBe "/view-your-vat-returns/returns?year=2017"
+      controllers.routes.ReturnObligationsController.completedReturns(2017).url shouldBe "/view-your-vat-returns/returns/2017"
     }
   }
 

--- a/test/views/CompletedReturnsViewSpec.scala
+++ b/test/views/CompletedReturnsViewSpec.scala
@@ -40,7 +40,7 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
     val period = ".divider--bottom p"
     def obligation(number: Int): String = s".divider--bottom .list-bullet li:nth-of-type($number)"
     def obligationLink(number: Int): String = s".divider--bottom .list-bullet li:nth-of-type($number) > a"
-    val otherReturns = "h3"
+    val otherReturns = "div.column-two-thirds > h3"
     val otherReturnsGuidance = "div > div > p:nth-child(6)"
     val otherReturnsLink = "div > div > p:nth-child(6) > a"
   }

--- a/test/views/CompletedReturnsViewSpec.scala
+++ b/test/views/CompletedReturnsViewSpec.scala
@@ -127,7 +127,7 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
       elementText(Selectors.returnsHeading) shouldBe "2018 Returns"
     }
 
-    "have the correct alternate content for when no returns are found" in {
+    "have the correct alternate content when no returns are found" in {
       // TODO: this will change next iteration
       elementText(Selectors.noReturnsFound) shouldBe "Alternate Content"
     }

--- a/test/views/CompletedReturnsViewSpec.scala
+++ b/test/views/CompletedReturnsViewSpec.scala
@@ -25,25 +25,31 @@ import org.jsoup.nodes.Document
 class CompletedReturnsViewSpec extends ViewBaseSpec {
 
   object Selectors {
-    val pageHeading = "#content h1"
-    val submitThroughSoftware = "#content > article > div > div > p:nth-child(2)"
-    val tableCaption = "#content caption"
-    val periodEndingColumnHeading = "#completedReturns > thead > tr > th:nth-child(1)"
-    val statusColumnHeading = "#completedReturns > thead > tr > th:nth-child(2)"
-    val returnDetailsColumnHeading = "#completedReturns > thead > tr > th:nth-child(3)"
-    val periodEndingOutstanding = "#completedReturns > tbody:nth-child(3) > tr:nth-child(1) > td:nth-child(1)"
-    val periodEndingFulfilled = "#completedReturns > tbody:nth-child(3) > tr:nth-child(2) > td:nth-child(1)"
-    val statusOutstanding = "#completedReturns > tbody:nth-child(3) > tr:nth-child(1) > td:nth-child(2)"
-    val statusFulfilled = "#completedReturns > tbody:nth-child(3) > tr:nth-child(2) > td:nth-child(2)"
-    val detailsOutstanding = "#completedReturns > tbody:nth-child(3) > tr:nth-child(1) > td:nth-child(3)"
-    val detailsFulfilled = "#completedReturns > tbody:nth-child(3) > tr:nth-child(2) > td:nth-child(3) > a"
-    val noReturns = "#content h2"
-    val earlierReturns = "#content > article > div > div > p:nth-child(4)"
+    val pageHeading = "h1"
+    val submitThroughSoftware = "div > div > p:nth-child(2)"
+    val noReturnsFound = "div > div > section > p"
+    val tabOne = ".tabs-nav li:nth-of-type(1)"
+    val tabOneHiddenText = ".tabs-nav li:nth-of-type(1) span"
+    val tabTwo = ".tabs-nav li:nth-of-type(2)"
+    val tabTwoHiddenText = ".tabs-nav li:nth-of-type(2) span"
+    val tabThree = ".tabs-nav li:nth-of-type(3)"
+    val tabThreeHiddenText = ".tabs-nav li:nth-of-type(3) span"
+    val tabFour = ".tabs-nav li:nth-of-type(4)"
+    val tabFourHiddenText = ".tabs-nav li:nth-of-type(4) span"
+    val returnsHeading = ".divider--bottom h2"
+    val period = ".divider--bottom p"
+    def obligation(number: Int): String = s".divider--bottom .list-bullet li:nth-of-type($number)"
+    def obligationLink(number: Int): String = s".divider--bottom .list-bullet li:nth-of-type($number) > a"
+    val otherReturns = "h3"
+    val otherReturnsGuidance = "div > div > p:nth-child(6)"
+    val otherReturnsLink = "div > div > p:nth-child(6) > a"
   }
 
-  "Rendering the VAT Returns page" should {
+  val returnYears = Seq(2018, 2017, 2016, 2015)
 
-    lazy val view = views.html.returns.completedReturns(VatReturnObligations(Seq()))
+  "Rendering the VAT Returns page with no returns for the selected year of 2018" should {
+
+    lazy val view = views.html.returns.completedReturns(VatReturnObligations(Seq()), returnYears, 2018)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "have the correct document title" in {
@@ -58,12 +64,91 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
       elementText(Selectors.submitThroughSoftware) shouldBe "You submit returns through your accounting software."
     }
 
-    "have the correct message regarding viewing earlier returns" in {
-      elementText(Selectors.earlierReturns) shouldBe "You can also view earlier returns you submitted before using accounting software."
+    "have tabs for each return year which" should {
+
+      "tab one" should {
+
+        "have the text '2018'" in {
+          elementText(Selectors.tabOne) should include("2018")
+        }
+
+        "contain visually hidden text" in {
+          elementText(Selectors.tabOneHiddenText) shouldBe "Currently viewing returns from 2018"
+        }
+      }
+
+      "tab two" should {
+
+        "have the text '2017'" in {
+          elementText(Selectors.tabTwo) should include("2017")
+        }
+
+        s"contain a link to ${controllers.routes.ReturnObligationsController.completedReturns(2017).url}" in {
+          element(Selectors.tabTwo).select("a").attr("href") shouldBe controllers.routes.ReturnObligationsController.completedReturns(2017).url
+        }
+
+        "contain visually hidden text" in {
+          elementText(Selectors.tabTwoHiddenText) shouldBe "View returns from 2017"
+        }
+      }
+
+      "tab three" should {
+
+        "have the text '2016'" in {
+          elementText(Selectors.tabThree) should include("2016")
+        }
+
+        s"contain a link to ${controllers.routes.ReturnObligationsController.completedReturns(2016).url}" in {
+          element(Selectors.tabThree).select("a").attr("href") shouldBe controllers.routes.ReturnObligationsController.completedReturns(2016).url
+        }
+
+        "contain visually hidden text" in {
+          elementText(Selectors.tabThreeHiddenText) shouldBe "View returns from 2016"
+        }
+      }
+
+      "tab four" should {
+
+        "have the text '2015'" in {
+          elementText(Selectors.tabFour) should include("2015")
+        }
+
+        s"contain a link to ${controllers.routes.ReturnObligationsController.completedReturns(2015).url}" in {
+          element(Selectors.tabFour).select("a").attr("href") shouldBe controllers.routes.ReturnObligationsController.completedReturns(2015).url
+        }
+
+        "contain visually hidden text" in {
+          elementText(Selectors.tabFourHiddenText) shouldBe "View returns from 2015"
+        }
+      }
+    }
+
+    "have the correct return heading" in {
+      elementText(Selectors.returnsHeading) shouldBe "2018 Returns"
+    }
+
+    "have the correct alternate content for when no returns are found" in {
+      // TODO: this will change next iteration
+      elementText(Selectors.noReturnsFound) shouldBe "Alternate Content"
+    }
+
+    "the other returns guidance" should {
+
+      "have the correct title" in {
+        elementText(Selectors.otherReturns) shouldBe "Other returns"
+      }
+
+      "contain the correct text" in {
+        elementText(Selectors.otherReturnsGuidance) shouldBe "You can also view returns submitted before using accounting software (opens in new tab)."
+      }
+
+      "contain a link to ''" in {
+        element(Selectors.otherReturnsLink).attr("href") shouldBe ""
+      }
     }
   }
 
-  "Rendering the VAT Returns page with one outstanding and one fulfilled VAT Return" should {
+  "Rendering the VAT Returns page with multiple returns for the selected year of 2018" should {
 
     lazy val exampleReturns: VatReturnObligations = VatReturnObligations(
       Seq(
@@ -79,64 +164,44 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
           LocalDate.parse("2017-01-01"),
           LocalDate.parse("2017-09-30"),
           LocalDate.parse("2018-10-31"),
-          "F",
+          "O",
           None,
           "#001"
         )
       )
     )
 
-    lazy val view = views.html.returns.completedReturns(exampleReturns)
+    lazy val view = views.html.returns.completedReturns(exampleReturns, returnYears, 2018)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct table caption" in {
-      elementText(Selectors.tableCaption) shouldBe "VAT returns found since opting in for Making Tax Digital For Business"
+    "have the correct return heading" in {
+      elementText(Selectors.returnsHeading) shouldBe "2018 Returns"
     }
 
-    "have the correct heading for the period ending column" in {
-      elementText(Selectors.periodEndingColumnHeading) shouldBe "Period ending"
+    "have the correct period text" in {
+      elementText(Selectors.period) shouldBe "For the period:"
     }
 
-    "have the correct heading for the status column" in {
-      elementText(Selectors.statusColumnHeading) shouldBe "Status"
+    "contain the first return which" should {
+
+      "contains the correct obligation period text" in {
+        elementText(Selectors.obligation(1)) shouldBe "1 January to 31 December 2017"
+      }
+
+      "contains the correct link to view a specific return" in {
+        element(Selectors.obligationLink(1)).attr("href") shouldBe controllers.routes.ReturnsController.vatReturnDetails("2017-01-01", "2017-12-31").url
+      }
     }
 
-    "have the correct heading for the return details column" in {
-      elementText(Selectors.returnDetailsColumnHeading) shouldBe "Return details"
-    }
+    "contain the second return which" should {
 
-    "have the correct period ending for the outstanding return" in {
-      elementText(Selectors.periodEndingOutstanding) shouldBe "31 December 2017"
-    }
+      "contains the correct obligation period text" in {
+        elementText(Selectors.obligation(2)) shouldBe "1 January to 30 September 2017"
+      }
 
-    "have the correct period ending for the fulfilled return" in {
-      elementText(Selectors.periodEndingFulfilled) shouldBe "30 September 2017"
-    }
-
-    "have the correct status for the outstanding return" in {
-      elementText(Selectors.statusOutstanding) shouldBe "Due 31 January 2018"
-    }
-
-    "have the correct status for the fulfilled return" in {
-      elementText(Selectors.statusFulfilled) shouldBe "Received"
-    }
-
-    "have the correct return details for the outstanding return" in {
-      elementText(Selectors.detailsOutstanding) shouldBe "Not yet submitted"
-    }
-
-    "have the correct return details for the fulfilled return" in {
-      elementText(Selectors.detailsFulfilled) shouldBe "View 30 September 2017 Return"
-    }
-  }
-
-  "Rendering the VAT Returns page with no available VAT Returns" should {
-
-    lazy val view = views.html.returns.completedReturns(VatReturnObligations(Seq()))
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct message that there are no returns" in {
-      elementText(Selectors.noReturns) shouldBe "You have no returns."
+      "contains the correct link to view a specific return" in {
+        element(Selectors.obligationLink(2)).attr("href") shouldBe controllers.routes.ReturnsController.vatReturnDetails("2017-01-01", "2017-09-30").url
+      }
     }
   }
 }

--- a/test/views/CompletedReturnsViewSpec.scala
+++ b/test/views/CompletedReturnsViewSpec.scala
@@ -64,7 +64,7 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
       elementText(Selectors.submitThroughSoftware) shouldBe "You submit returns through your accounting software."
     }
 
-    "have tabs for each return year which" should {
+    "have tabs for each return year" should {
 
       "tab one" should {
 

--- a/test/views/CompletedReturnsViewSpec.scala
+++ b/test/views/CompletedReturnsViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import java.time.LocalDate
 
-import models.{VatReturnObligation, VatReturnObligations}
+import models.viewModels.{ReturnObligationsViewModel, VatReturnsViewModel}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -49,7 +49,7 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
 
   "Rendering the VAT Returns page with no returns for the selected year of 2018" should {
 
-    lazy val view = views.html.returns.completedReturns(VatReturnObligations(Seq()), returnYears, 2018)
+    lazy val view = views.html.returns.completedReturns(VatReturnsViewModel(returnYears, 2018, Seq()))
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "have the correct document title" in {
@@ -150,28 +150,21 @@ class CompletedReturnsViewSpec extends ViewBaseSpec {
 
   "Rendering the VAT Returns page with multiple returns for the selected year of 2018" should {
 
-    lazy val exampleReturns: VatReturnObligations = VatReturnObligations(
+    lazy val exampleReturns: Seq[ReturnObligationsViewModel] =
       Seq(
-        VatReturnObligation(
+        ReturnObligationsViewModel(
           LocalDate.parse("2017-01-01"),
           LocalDate.parse("2017-12-31"),
-          LocalDate.parse("2018-01-31"),
-          "O",
-          None,
           "#001"
         ),
-        VatReturnObligation(
+        ReturnObligationsViewModel(
           LocalDate.parse("2017-01-01"),
           LocalDate.parse("2017-09-30"),
-          LocalDate.parse("2018-10-31"),
-          "O",
-          None,
           "#001"
         )
       )
-    )
 
-    lazy val view = views.html.returns.completedReturns(exampleReturns, returnYears, 2018)
+    lazy val view = views.html.returns.completedReturns(VatReturnsViewModel(returnYears, 2018, exampleReturns))
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     "have the correct return heading" in {


### PR DESCRIPTION
Notes: 
- periodKey isn't used currently but will be needed when passed to 9 box return page later
- where no return obligations are returned for a year, dummy content is set for now while design put some content through testing