### PR TITLE
Update to breadcrumbs styling to remove unneccessary padding

### DIFF
--- a/app/views/templates/formatters/breadcrumbs/navigationBreadcrumb.scala.html
+++ b/app/views/templates/formatters/breadcrumbs/navigationBreadcrumb.scala.html
@@ -16,8 +16,8 @@
 
 @(links: Map[String, String], currentPage: String)
 
-<div class="breadcrumbs">
-    <ol>
+<div class="breadcrumbs soft--top">
+    <ol class="push--top">
         @links.map {
             case (key, value) => { <li><a href="@key">@value</a></li> }
         }

--- a/test/views/templates/formatters/breadcrumbs/NavigationBreadcrumbTemplateSpec.scala
+++ b/test/views/templates/formatters/breadcrumbs/NavigationBreadcrumbTemplateSpec.scala
@@ -33,8 +33,8 @@ class NavigationBreadcrumbTemplateSpec extends TemplateBaseSpec {
 
     val expectedMarkup = Html(
       s"""
-         |<div class="breadcrumbs">
-         |    <ol>
+         |<div class="breadcrumbs soft--top">
+         |    <ol class="push--top">
          |        <li><a href="/link-url1">link text1</a></li>
          |        <li><a href="/link-url2">link text2</a></li>
          |        <li>$currentPage</li>


### PR DESCRIPTION
This was done in a vat-summary too as part of this PR: 

- https://github.com/hmrc/vat-summary-frontend/pull/181

 
so I updated it here too. 