### PR TITLE
BTAT-4025: Added isPartialMigration to VAT subscription connector models

### DIFF
--- a/app/controllers/ReturnsController.scala
+++ b/app/controllers/ReturnsController.scala
@@ -153,7 +153,8 @@ class ReturnsController @Inject()(val messagesApi: MessagesApi,
       showReturnsBreadcrumb = isReturnsPageRequest,
       currentYear = dateService.now().getYear,
       hasFlatRateScheme = customerDetail.fold(false)(_.hasFlatRateScheme),
-      hasDirectDebit = directDebitStatus
+      hasDirectDebit = directDebitStatus,
+      isHybridUser = customerDetail.fold(false)(_.isPartialMigration)
     )
   }
 }

--- a/app/models/CustomerInformation.scala
+++ b/app/models/CustomerInformation.scala
@@ -23,7 +23,8 @@ case class CustomerInformation(organisationName: Option[String],
                                firstName: Option[String],
                                lastName: Option[String],
                                tradingName: Option[String],
-                               hasFlatRateScheme: Boolean)
+                               hasFlatRateScheme: Boolean,
+                               isPartialMigration: Option[Boolean])
 
 
 object CustomerInformation {
@@ -34,6 +35,7 @@ object CustomerInformation {
       (JsPath \ "firstName").readNullable[String] and
       (JsPath \ "lastName").readNullable[String] and
       (JsPath \ "tradingName").readNullable[String] and
-      (JsPath \ "hasFlatRateScheme").read[Boolean]
+      (JsPath \ "hasFlatRateScheme").read[Boolean] and
+      (JsPath \ "isPartialMigration").readNullable[Boolean]
     ) (CustomerInformation.apply _)
 }

--- a/app/models/customer/CustomerDetail.scala
+++ b/app/models/customer/CustomerDetail.scala
@@ -16,4 +16,4 @@
 
 package models.customer
 
-case class CustomerDetail(entityName: String, hasFlatRateScheme: Boolean)
+case class CustomerDetail(entityName: String, hasFlatRateScheme: Boolean, isPartialMigration: Boolean)

--- a/app/models/viewModels/VatReturnViewModel.scala
+++ b/app/models/viewModels/VatReturnViewModel.scala
@@ -30,5 +30,6 @@ case class VatReturnViewModel(entityName: Option[String],
                               showReturnsBreadcrumb: Boolean,
                               currentYear: Int,
                               hasFlatRateScheme: Boolean,
-                              hasDirectDebit: Boolean
+                              hasDirectDebit: Boolean,
+                              isHybridUser: Boolean
                              )

--- a/it/connectors/VatSubscriptionConnectorISpec.scala
+++ b/it/connectors/VatSubscriptionConnectorISpec.scala
@@ -49,7 +49,8 @@ class VatSubscriptionConnectorISpec extends IntegrationBaseSpec {
           Some("Vincent"),
           Some("Vatreturn"),
           Some("Cheapo Clothing"),
-          hasFlatRateScheme
+          hasFlatRateScheme,
+          Some(true)
         ))
         private val result = await(connector.getCustomerInfo("999999999"))
 

--- a/it/stubs/CustomerInfoStub.scala
+++ b/it/stubs/CustomerInfoStub.scala
@@ -41,7 +41,8 @@ object CustomerInfoStub extends WireMockMethods {
       |   "firstName" : "Vincent",
       |   "lastName" : "Vatreturn",
       |   "tradingName" : "Cheapo Clothing",
-      |   "hasFlatRateScheme": true
+      |   "hasFlatRateScheme": true,
+      |   "isPartialMigration":true
       |}""".stripMargin
   )
 

--- a/test/connectors/httpParsers/CustomerInfoHttpParserSpec.scala
+++ b/test/connectors/httpParsers/CustomerInfoHttpParserSpec.scala
@@ -40,7 +40,8 @@ class CustomerInfoHttpParserSpec extends UnitSpec {
             "firstName" -> "John",
             "lastName" -> "Smith",
             "tradingName" -> "Cheapo Clothing",
-            "hasFlatRateScheme" -> hasFlatRateSchemeYes
+            "hasFlatRateScheme" -> hasFlatRateSchemeYes,
+            "isPartialMigration" -> true
           )
         )
       )
@@ -50,7 +51,8 @@ class CustomerInfoHttpParserSpec extends UnitSpec {
         Some("John"),
         Some("Smith"),
         Some("Cheapo Clothing"),
-        hasFlatRateSchemeYes
+        hasFlatRateSchemeYes,
+        Some(true)
       ))
       val result = CustomerInfoReads.read("", "", httpResponse)
 

--- a/test/controllers/ReturnsControllerSpec.scala
+++ b/test/controllers/ReturnsControllerSpec.scala
@@ -58,7 +58,7 @@ class ReturnsControllerSpec extends ControllerBaseSpec {
   )
 
   val exampleEntityName: Option[String] = Some("Cheapo Clothing")
-  val exampleCustomerDetail: Option[CustomerDetail] = Some(CustomerDetail("Cheapo Clothing", hasFlatRateScheme = true))
+  val exampleCustomerDetail: Option[CustomerDetail] = Some(CustomerDetail("Cheapo Clothing", hasFlatRateScheme = true, isPartialMigration = false))
 
   val examplePayment: Payment = Payment(
     "VAT",

--- a/test/controllers/ReturnsControllerSpec.scala
+++ b/test/controllers/ReturnsControllerSpec.scala
@@ -299,7 +299,8 @@ class ReturnsControllerSpec extends ControllerBaseSpec {
         showReturnsBreadcrumb = true,
         currentYear = 2018,
         hasFlatRateScheme = true,
-        hasDirectDebit = false
+        hasDirectDebit = false,
+        isHybridUser = false
       )
 
       (mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01"))

--- a/test/models/CustomerInformationSpec.scala
+++ b/test/models/CustomerInformationSpec.scala
@@ -30,7 +30,8 @@ class CustomerInformationSpec extends UnitSpec {
       Some("John"),
       Some("Smith"),
       Some("Cheapo Clothing"),
-      hasFlatRateSchemeYes
+      hasFlatRateSchemeYes,
+      Some(true)
     )
 
     val exampleInputString =
@@ -39,7 +40,8 @@ class CustomerInformationSpec extends UnitSpec {
         |"firstName":"John",
         |"lastName":"Smith",
         |"tradingName":"Cheapo Clothing",
-        |"hasFlatRateScheme":true
+        |"hasFlatRateScheme":true,
+        |"isPartialMigration":true
         |}"""
         .stripMargin.replace("\n", "")
 
@@ -49,7 +51,8 @@ class CustomerInformationSpec extends UnitSpec {
         |"firstName":"John",
         |"lastName":"Smith",
         |"tradingName":"Cheapo Clothing",
-        |"hasFlatRateScheme":true
+        |"hasFlatRateScheme":true,
+        |"isPartialMigration":true
         |}"""
         .stripMargin.replace("\n", "")
 

--- a/test/views/VatReturnDetailsViewSpec.scala
+++ b/test/views/VatReturnDetailsViewSpec.scala
@@ -95,7 +95,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = true,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -243,7 +244,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = true,
       currentYear,
       hasFlatRateScheme = false,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -391,7 +393,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = false,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -446,7 +449,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = false,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -506,7 +510,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = false,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -562,7 +567,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = false,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -606,7 +612,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = true,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -645,7 +652,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = true,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = true
+      hasDirectDebit = true,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)
@@ -685,7 +693,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
       showReturnsBreadcrumb = true,
       currentYear,
       hasFlatRateScheme = true,
-      hasDirectDebit = false
+      hasDirectDebit = false,
+      isHybridUser = false
     )
 
     lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)


### PR DESCRIPTION
Currently this just retrieves the boolean and passes it to view model, doesn't do anything with it yet