### PR TITLE
BTAT-5970 Added support for POA Return charges and relevant IT tests

### DIFF
--- a/app/connectors/httpParsers/PaymentsHttpParser.scala
+++ b/app/connectors/httpParsers/PaymentsHttpParser.scala
@@ -52,7 +52,9 @@ object PaymentsHttpParser extends ResponseHttpParsers {
       "VAT Return Credit Charge",
       "VAT EC Debit Charge",
       "VAT AA Return Debit Charge",
-      "VAT AA Return Credit Charge"
+      "VAT AA Return Credit Charge",
+      "VAT POA Return Debit Charge",
+      "VAT POA Return Credit Charge"
     )
 
     val charges: Seq[JsValue] = (json \ "financialTransactions").as[JsArray].value

--- a/it/pages/VatReturnDetailsPageSpec.scala
+++ b/it/pages/VatReturnDetailsPageSpec.scala
@@ -118,6 +118,40 @@ class VatReturnDetailsPageSpec extends IntegrationBaseSpec {
       }
     }
 
+    "the user is authenticated, has an outstanding obligation and a related " +
+      "VAT POA Return Credit Charge with an outstanding amount owed to the user" should {
+
+      "return 200" in new PaymentReturnRouteTest {
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          CustomerInfoStub.stubCustomerInfo
+          returnsStub.stubSuccessfulVatReturn
+          obligationsStub.stubFulfilledObligations
+          FinancialDataStub.stubPOAReturnCreditCharge
+        }
+
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.OK
+      }
+    }
+
+    "the user is authenticated, has an outstanding obligation and a related " +
+      "VAT POA Return Debit Charge with an outstanding amount of zero" should {
+
+      "return 200" in new PaymentReturnRouteTest {
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          CustomerInfoStub.stubCustomerInfo
+          returnsStub.stubSuccessfulVatReturn
+          obligationsStub.stubFulfilledObligations
+          FinancialDataStub.stubPOAReturnDebitCharge(0)
+        }
+
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.OK
+      }
+    }
+
     "the user is authenticated, has outstanding obligations and no related charge" should {
 
       "return 200" in new ReturnRouteTest {
@@ -165,6 +199,23 @@ class VatReturnDetailsPageSpec extends IntegrationBaseSpec {
           returnsStub.stubSuccessfulVatReturn
           obligationsStub.stubFulfilledObligations
           FinancialDataStub.stubAAReturnDebitChargeOutstandingPayment(5000)
+        }
+
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.OK
+      }
+    }
+
+    "the user is authenticated, has an outstanding obligation and a related " +
+      "VAT POA Return Debit Charge with an outstanding amount owed to HMRC" should {
+
+      "return 200" in new PaymentReturnRouteTest {
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          CustomerInfoStub.stubCustomerInfo
+          returnsStub.stubSuccessfulVatReturn
+          obligationsStub.stubFulfilledObligations
+          FinancialDataStub.stubPOAReturnDebitCharge(5000)
         }
 
         val response: WSResponse = await(request().get())

--- a/it/stubs/FinancialDataStub.scala
+++ b/it/stubs/FinancialDataStub.scala
@@ -32,12 +32,22 @@ object FinancialDataStub extends WireMockMethods{
 
   def stubAAReturnDebitChargeOutstandingPayment(outstandingAmount: BigDecimal): StubMapping = {
     when(method = GET, uri = financialDataUri)
-      .thenReturn(status = OK, body = aaDebitChargePayment(outstandingAmount))
+      .thenReturn(status = OK, body = generateTransaction("VAT AA Return Debit Charge", outstandingAmount))
   }
 
   def stubAAReturnCreditChargeOutstandingPayment: StubMapping = {
     when(method = GET, uri = financialDataUri)
-      .thenReturn(status = OK, body = aaCreditChargePayment)
+      .thenReturn(status = OK, body = generateTransaction("VAT AA Return Credit Charge", -100))
+  }
+
+  def stubPOAReturnDebitCharge(outstandingAmount: BigDecimal): StubMapping = {
+    when(method = GET, uri = financialDataUri)
+      .thenReturn(status = OK, body = generateTransaction("VAT POA Return Debit Charge", outstandingAmount))
+  }
+
+  def stubPOAReturnCreditCharge: StubMapping = {
+    when(method = GET, uri = financialDataUri)
+      .thenReturn(status = OK, body = generateTransaction("VAT POA Return Credit Charge", -100))
   }
 
   def stubAllOutstandingPayments: StubMapping = {
@@ -90,7 +100,8 @@ object FinancialDataStub extends WireMockMethods{
        |    "regimeType" : "VATC",
        |    "processingDate" : "2017-03-07T09:30:00.000Z",
        |    "financialTransactions" : [
-       |      ${generateCharge(chargeType, "#001", outstandingAmount)}
+       |      ${generateCharge(chargeType, "#001", outstandingAmount)},
+       |      ${generateCharge("Irrelevant Charge", "#001", 1000)}
        |    ]
        |  }""".stripMargin
   )
@@ -104,32 +115,6 @@ object FinancialDataStub extends WireMockMethods{
       |    "financialTransactions" : [
       |      ${generateCharge("VAT Return Debit Charge", "#001", 4000)},
       |      ${generateCharge("VAT Return Debit Charge", "#002", 0)}
-      |    ]
-      |  }""".stripMargin
-  )
-
-  private def aaDebitChargePayment(outstandingAmount: BigDecimal): JsValue = Json.parse(
-    s"""{
-      |    "idType" : "VRN",
-      |    "idNumber" : 555555555,
-      |    "regimeType" : "VATC",
-      |    "processingDate" : "2017-03-07T09:30:00.000Z",
-      |    "financialTransactions" : [
-      |      ${generateCharge("VAT AA Return Debit Charge", "#001", outstandingAmount)},
-      |      ${generateCharge("VAT AA Monthly Instalment", "#001", 0)}
-      |    ]
-      |  }""".stripMargin
-  )
-
-  private val aaCreditChargePayment: JsValue = Json.parse(
-    s"""{
-      |    "idType" : "VRN",
-      |    "idNumber" : 555555555,
-      |    "regimeType" : "VATC",
-      |    "processingDate" : "2017-03-07T09:30:00.000Z",
-      |    "financialTransactions" : [
-      |      ${generateCharge("VAT AA Return Credit Charge", "#001", -2000)},
-      |      ${generateCharge("VAT AA Monthly Instalment", "#001", 0)}
       |    ]
       |  }""".stripMargin
   )

--- a/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/PaymentsHttpParserSpec.scala
@@ -78,6 +78,28 @@ class PaymentsHttpParserSpec extends UnitSpec {
               ),
               "outstandingAmount" -> -1000,
               "periodKey" -> "#006"
+            ),
+            Json.obj(
+              "mainType" -> "VAT POA Return Charge",
+              "chargeType" -> "VAT POA Return Debit Charge",
+              "taxPeriodFrom" -> "2020-12-01",
+              "taxPeriodTo" -> "2021-01-01",
+              "items" -> Json.arr(
+                Json.obj("dueDate" -> "2021-10-25")
+              ),
+              "outstandingAmount" -> 1000,
+              "periodKey" -> "#007"
+            ),
+            Json.obj(
+              "mainType" -> "VAT POA Return Charge",
+              "chargeType" -> "VAT POA Return Credit Charge",
+              "taxPeriodFrom" -> "2021-12-01",
+              "taxPeriodTo" -> "2022-01-01",
+              "items" -> Json.arr(
+                Json.obj("dueDate" -> "2022-10-25")
+              ),
+              "outstandingAmount" -> -1000,
+              "periodKey" -> "#008"
             )
           )
         )
@@ -119,6 +141,24 @@ class PaymentsHttpParserSpec extends UnitSpec {
           outstandingAmount = BigDecimal(-1000.00),
           clearedAmount = BigDecimal(0),
           periodKey = "#006"
+        ),
+        Payment(
+          "VAT POA Return Debit Charge",
+          start = LocalDate.parse("2020-12-01"),
+          end = LocalDate.parse("2021-01-01"),
+          due = LocalDate.parse("2021-10-25"),
+          outstandingAmount = BigDecimal(1000.00),
+          clearedAmount = BigDecimal(0),
+          periodKey = "#007"
+        ),
+        Payment(
+          "VAT POA Return Credit Charge",
+          start = LocalDate.parse("2021-12-01"),
+          end = LocalDate.parse("2022-01-01"),
+          due = LocalDate.parse("2022-10-25"),
+          outstandingAmount = BigDecimal(-1000.00),
+          clearedAmount = BigDecimal(0),
+          periodKey = "#008"
         )
       )))
 


### PR DESCRIPTION
Also a small refactor to the IT tests transaction helper to add an irrelevant charge with the same period key, to prove that the page still loads when an unsupported charge (e.g. an instalment) has the same period key. I updated the AA tests to use this helper too.