### PR TITLE
BTAT-6363 Added logic to filter out pre-ETMP fulfilled obligations

### DIFF
--- a/app/audit/AuditingService.scala
+++ b/app/audit/AuditingService.scala
@@ -19,7 +19,6 @@ package audit
 import models._
 
 import config.{AppConfig, FrontendAuditConnector}
-import controllers.routes
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
@@ -80,12 +79,5 @@ class AuditingService @Inject()(appConfig: AppConfig, auditConnector: FrontendAu
     case Disabled =>
       Logger.debug(s"Auditing Disabled")
     //$COVERAGE-ON$
-  }
-
-  def openObligationsAudit(auditModel: ViewOpenVatObligationsAuditModel)(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
-    extendedAudit(
-      auditModel,
-      routes.ReturnDeadlinesController.returnDeadlines().url
-    )
   }
 }

--- a/app/audit/AuditingService.scala
+++ b/app/audit/AuditingService.scala
@@ -16,8 +16,10 @@
 
 package audit
 
-import audit.models.{AuditModel, ExtendedAuditModel}
+import models._
+
 import config.{AppConfig, FrontendAuditConnector}
+import controllers.routes
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
@@ -78,5 +80,12 @@ class AuditingService @Inject()(appConfig: AppConfig, auditConnector: FrontendAu
     case Disabled =>
       Logger.debug(s"Auditing Disabled")
     //$COVERAGE-ON$
+  }
+
+  def openObligationsAudit(auditModel: ViewOpenVatObligationsAuditModel)(implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
+    extendedAudit(
+      auditModel,
+      routes.ReturnDeadlinesController.returnDeadlines().url
+    )
   }
 }

--- a/app/common/EnrolmentKeys.scala
+++ b/app/common/EnrolmentKeys.scala
@@ -25,6 +25,7 @@ object EnrolmentKeys {
   val mtdVatDelegatedAuthRule: String = "mtd-vat-auth"
   val agentAffinityGroup: String = "Agent"
   val vatIdentifierId: String = "VRN"
+  val agentIdentifierId: String = "AgentReferenceNumber"
   val activated: String = "Activated"
 
 }

--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -20,5 +20,5 @@ object SessionKeys {
 
   val mtdVatMandationStatus: String = "mtdVatMandationStatus"
   val clientVrn: String = "CLIENT_VRN"
-
+  val customerMigratedToETMPDate = "customerMigratedToETMPDate"
 }

--- a/app/controllers/ReturnDeadlinesController.scala
+++ b/app/controllers/ReturnDeadlinesController.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import java.time.LocalDate
+
+import audit.AuditingService
+import audit.models.ViewOpenVatObligationsAuditModel
+import common.SessionKeys
+import config.AppConfig
+import javax.inject.{Inject, Singleton}
+import models.viewModels.ReturnDeadlineViewModel
+import models._
+import play.api.Logger
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, Request, Result}
+import play.twirl.api.{Html, HtmlFormat}
+import services.{DateService, EnrolmentsAuthService, ReturnsService, ServiceInfoService}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ReturnDeadlinesController @Inject()(val messagesApi: MessagesApi,
+                                          enrolmentsAuthService: EnrolmentsAuthService,
+                                          returnsService: ReturnsService,
+                                          authorisedController: AuthorisedController,
+                                          dateService: DateService,
+                                          serviceInfoService: ServiceInfoService,
+                                          implicit val appConfig: AppConfig,
+                                          auditService: AuditingService)
+  extends FrontendController with I18nSupport {
+
+
+  private[controllers] def serviceInfoCall()(implicit user: User, req: Request[_], ec: ExecutionContext): Future[Html] = {
+    if (user.isAgent) Future.successful(HtmlFormat.empty) else serviceInfoService.getServiceInfoPartial
+  }
+
+  private[controllers] def toReturnDeadlineViewModel(obligation: VatReturnObligation, date: LocalDate): ReturnDeadlineViewModel = {
+    ReturnDeadlineViewModel(
+      obligation.due,
+      obligation.start,
+      obligation.end,
+      obligation.due.isBefore(date),
+      obligation.periodKey
+    )
+  }
+
+  def returnDeadlines(): Action[AnyContent] = authorisedController.authorisedAction { implicit request =>
+
+    implicit user =>
+      val openObligations = returnsService.getOpenReturnObligations(user)
+      val currentDate = dateService.now()
+
+      openObligations.flatMap {
+        case Right(VatReturnObligations(obligations)) =>
+          serviceInfoCall().flatMap { serviceInfoContent =>
+            auditService.openObligationsAudit(ViewOpenVatObligationsAuditModel(user, obligations))
+
+            if (obligations.isEmpty) {
+              noUpcomingObligationsAction(serviceInfoContent, currentDate)
+            } else {
+              upcomingObligationsAction(obligations.map(toReturnDeadlineViewModel(_, currentDate)), serviceInfoContent)
+            }
+          }
+        case Left(error) =>
+          Logger.warn("[ReturnObligationsController][returnDeadlines] error: " + error.toString)
+          Future.successful(InternalServerError(views.html.errors.technicalProblem()))
+      }
+  }
+
+  private[controllers] def noUpcomingObligationsAction(serviceInfoContent: Html, currentDate: LocalDate)
+                                                      (implicit request: Request[AnyContent],
+                                                      user: User): Future[Result] = {
+    returnsService.getFulfilledObligations(currentDate).map {
+      case Right(VatReturnObligations(Seq())) => Ok(views.html.returns.noUpcomingReturnDeadlines(None, serviceInfoContent))
+      case Right(VatReturnObligations(obligations)) =>
+        val lastFulfilledObligation: VatReturnObligation = returnsService.getLastObligation(obligations)
+        Ok(views.html.returns.noUpcomingReturnDeadlines(Some(toReturnDeadlineViewModel(lastFulfilledObligation, currentDate)), serviceInfoContent))
+      case Left(error) =>
+        Logger.warn("[ReturnObligationsController][fulfilledObligationsAction] error: " + error.toString)
+        InternalServerError(views.html.errors.technicalProblem())
+    }
+  }
+
+  private[controllers] def upcomingObligationsAction(obligations: Seq[ReturnDeadlineViewModel],
+                                                     serviceInfoContent: Html)
+                                                    (implicit user: User, request: Request[AnyContent]): Future[Result] = {
+
+    def view(mandationStatus: String) = mandationStatus match {
+      case NonMtdfb.mandationStatus => views.html.returns.optOutReturnDeadlines(obligations, dateService.now(), serviceInfoContent)
+      case _ => views.html.returns.returnDeadlines(obligations, serviceInfoContent)
+    }
+
+    if (appConfig.features.submitReturnFeatures()) {
+      request.session.get(SessionKeys.mtdVatMandationStatus) match {
+        case Some(status) => Future.successful(Ok(view(status)))
+        case None =>
+          returnsService.getMandationStatus(user.vrn) map {
+            case Right(MandationStatus(status)) =>
+              Ok(view(status)).addingToSession(SessionKeys.mtdVatMandationStatus -> status)
+            case error =>
+              Logger.warn(s"[ReturnObligationsController][handleMandationStatus] - getMandationStatus returned an Error: $error")
+              InternalServerError(views.html.errors.technicalProblem())
+          }
+      }
+    } else {
+      Future.successful(Ok(views.html.returns.returnDeadlines(obligations, serviceInfoContent)))
+    }
+  }
+
+}

--- a/app/controllers/ReturnsController.scala
+++ b/app/controllers/ReturnsController.scala
@@ -51,6 +51,7 @@ class ReturnsController @Inject()(val messagesApi: MessagesApi,
   def vatReturn(year: Int, periodKey: String): Action[AnyContent] = authorisedController.authorisedAction {
     implicit request =>
       implicit user =>
+        implicit val migrationDate: Option[String] = request.session.get(SessionKeys.customerMigratedToETMPDate)
         if(validPeriodKey(periodKey)) {
           val isReturnsPageRequest = true
           val vatReturnCall = returnsService.getVatReturn(user, periodKey)
@@ -80,6 +81,7 @@ class ReturnsController @Inject()(val messagesApi: MessagesApi,
   def vatReturnViaPayments(periodKey: String): Action[AnyContent] = authorisedController.authorisedAction {
     implicit request =>
       implicit user =>
+        implicit val migrationDate: Option[String] = request.session.get(SessionKeys.customerMigratedToETMPDate)
         if(validPeriodKey(periodKey)) {
           val isReturnsPageRequest = false
           val vatReturnCall = returnsService.getVatReturn(user, periodKey)

--- a/app/models/CustomerInformation.scala
+++ b/app/models/CustomerInformation.scala
@@ -24,7 +24,8 @@ case class CustomerInformation(organisationName: Option[String],
                                lastName: Option[String],
                                tradingName: Option[String],
                                hasFlatRateScheme: Boolean,
-                               isPartialMigration: Option[Boolean])
+                               isPartialMigration: Option[Boolean],
+                               customerMigratedToETMPDate: Option[String])
 
 object CustomerInformation {
 
@@ -34,6 +35,7 @@ object CustomerInformation {
     (JsPath \ "customerDetails" \ "lastName").readNullable[String].orElse(Reads.pure(None)) and
     (JsPath \ "customerDetails" \ "tradingName").readNullable[String].orElse(Reads.pure(None)) and
     (JsPath \ "flatRateScheme").readNullable[JsValue].orElse(Reads.pure(None)).map(_.isDefined) and
-    (JsPath \\ "isPartialMigration").readNullable[Boolean]
+    (JsPath \\ "isPartialMigration").readNullable[Boolean] and
+    (JsPath \\ "customerMigratedToETMPDate").readNullable[String]
   )(CustomerInformation.apply _)
 }

--- a/app/models/errors/ServiceError.scala
+++ b/app/models/errors/ServiceError.scala
@@ -23,4 +23,5 @@ case object NotFoundError extends ServiceError
 case object VatReturnError extends ServiceError
 case object ObligationError extends ServiceError
 case object MandationStatusError extends ServiceError
+case object VatSubscriptionError extends ServiceError
 

--- a/app/services/ReturnsService.scala
+++ b/app/services/ReturnsService.scala
@@ -40,17 +40,45 @@ class ReturnsService @Inject()(vatObligationsConnector: VatObligationsConnector,
       case Left(_) => Left(VatReturnError)
     }
 
-  def getReturnObligationsForYear(user: User, searchYear: Int, status: Status.Value)
-                                 (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[VatReturnObligations]] = {
+  def getReturnObligationsForYear(user: User,
+                                  searchYear: Int,
+                                  status: Status.Value)
+                                 (implicit hc: HeaderCarrier,
+                                  ec: ExecutionContext,
+                                  migrationDate: Option[String]): Future[ServiceResponse[VatReturnObligations]] = {
     val from: LocalDate = LocalDate.parse(s"$searchYear-01-01")
     val to: LocalDate = LocalDate.parse(s"$searchYear-12-31")
 
-    vatObligationsConnector.getVatReturnObligations(user.vrn, Some(from), Some(to), status).map {
-      case Right(obligations) =>
-        Right(filterObligationsByDueDate(obligations, searchYear))
-      case Left(_) => Left(ObligationError)
+    vatObligationsConnector.getVatReturnObligations(user.vrn, Some(from), Some(to), status).flatMap {
+      case Right(obligations) if status == Status.Fulfilled =>
+        filterPreETMPObligations(obligations, migrationDate, user).map {
+          case Some(filteredObligations) => Right(filterObligationsByDueDate(filteredObligations, searchYear))
+          case _ => Left(VatSubscriptionError)
+        }
+      case Right(obligations) => Future.successful(Right(filterObligationsByDueDate(obligations, searchYear)))
+      case Left(_) => Future.successful(Left(ObligationError))
     }
   }
+
+  def filterPreETMPObligations(obligations: VatReturnObligations, migrationDate: Option[String], user: User)
+                              (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[VatReturnObligations]] =
+    migrationDate match {
+      case Some(date) =>
+        Future.successful(Some(
+          VatReturnObligations(obligations.obligations.filterNot(_.start.isBefore(LocalDate.parse(date))))
+        ))
+      case _ =>
+        vatSubscriptionConnector.getCustomerInfo(user.vrn).map {
+          case Right(customerInfo) =>
+            customerInfo.customerMigratedToETMPDate match {
+              case Some(date) =>
+                Some(VatReturnObligations(obligations.obligations.filterNot(_.start.isBefore(LocalDate.parse(date)))))
+              case _ =>
+                None
+            }
+          case Left(_) => None
+        }
+    }
 
   def getOpenReturnObligations(user: User)
                               (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[VatReturnObligations]] =
@@ -58,8 +86,6 @@ class ReturnsService @Inject()(vatObligationsConnector: VatObligationsConnector,
       case Right(obligations) => Right(obligations)
       case Left(_) => Left(ObligationError)
     }
-
-
 
   def getFulfilledObligations(currentDate: LocalDate)
                              (implicit user: User, hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[VatReturnObligations]] = {
@@ -72,8 +98,12 @@ class ReturnsService @Inject()(vatObligationsConnector: VatObligationsConnector,
 
   def getLastObligation(obligations: Seq[VatReturnObligation]): VatReturnObligation = obligations.sortWith(_.due isAfter _.due).head
 
-  def getObligationWithMatchingPeriodKey(user: User, year: Int, periodKey: String)
-                                        (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[VatReturnObligation]] =
+  def getObligationWithMatchingPeriodKey(user: User,
+                                         year: Int,
+                                         periodKey: String)
+                                        (implicit hc: HeaderCarrier,
+                                         ec: ExecutionContext,
+                                         migrationDate: Option[String]): Future[Option[VatReturnObligation]] =
     getReturnObligationsForYear(user, year, Status.Fulfilled).map {
       case Right(VatReturnObligations(obligations)) => obligations.find(_.periodKey == periodKey)
       case Left(_) => None

--- a/app/services/ReturnsService.scala
+++ b/app/services/ReturnsService.scala
@@ -24,6 +24,7 @@ import models.Obligation.Status
 import models.payments.{Payment, Payments}
 import models._
 import models.errors._
+import models.viewModels.ReturnDeadlineViewModel
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,6 +40,31 @@ class ReturnsService @Inject()(vatObligationsConnector: VatObligationsConnector,
       case Left(UnexpectedStatusError("404", _)) => Left(NotFoundError)
       case Left(_) => Left(VatReturnError)
     }
+
+  def getLastFullfilledObligation(obligationsResult: VatReturnObligations): Option[ReturnDeadlineViewModel]
+
+
+  /*
+    private[controllers] def fulfilledObligationsAction(obligationsResult: ServiceResponse[VatReturnObligations],
+                                                      serviceInfoContent: Html)
+                                                     (implicit request: Request[AnyContent],
+                                                      user: User): Result = {
+    obligationsResult match {
+      case Right(VatReturnObligations(Seq())) => Ok(views.html.returns.noUpcomingReturnDeadlines(None, serviceInfoContent))
+      case Right(VatReturnObligations(obligations)) =>
+        val lastFulfilledObligation: VatReturnObligation = returnsService.getLastObligation(obligations)
+        Ok(views.html.returns.noUpcomingReturnDeadlines(Some(ReturnDeadlineViewModel(
+          due = lastFulfilledObligation.due,
+          start = lastFulfilledObligation.start,
+          end = lastFulfilledObligation.end,
+          periodKey = lastFulfilledObligation.periodKey
+        )), serviceInfoContent))
+      case Left(error) =>
+        Logger.warn("[ReturnObligationsController][fulfilledObligationsAction] error: " + error.toString)
+        InternalServerError(views.html.errors.technicalProblem())
+    }
+  }
+   */
 
   def getReturnObligationsForYear(user: User, searchYear: Int, status: Status.Value)
                                  (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[VatReturnObligations]] = {
@@ -58,6 +84,8 @@ class ReturnsService @Inject()(vatObligationsConnector: VatObligationsConnector,
       case Right(obligations) => Right(obligations)
       case Left(_) => Left(ObligationError)
     }
+
+
 
   def getFulfilledObligations(currentDate: LocalDate)
                              (implicit user: User, hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[VatReturnObligations]] = {

--- a/app/services/ReturnsService.scala
+++ b/app/services/ReturnsService.scala
@@ -24,7 +24,6 @@ import models.Obligation.Status
 import models.payments.{Payment, Payments}
 import models._
 import models.errors._
-import models.viewModels.ReturnDeadlineViewModel
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -40,31 +39,6 @@ class ReturnsService @Inject()(vatObligationsConnector: VatObligationsConnector,
       case Left(UnexpectedStatusError("404", _)) => Left(NotFoundError)
       case Left(_) => Left(VatReturnError)
     }
-
-  def getLastFullfilledObligation(obligationsResult: VatReturnObligations): Option[ReturnDeadlineViewModel]
-
-
-  /*
-    private[controllers] def fulfilledObligationsAction(obligationsResult: ServiceResponse[VatReturnObligations],
-                                                      serviceInfoContent: Html)
-                                                     (implicit request: Request[AnyContent],
-                                                      user: User): Result = {
-    obligationsResult match {
-      case Right(VatReturnObligations(Seq())) => Ok(views.html.returns.noUpcomingReturnDeadlines(None, serviceInfoContent))
-      case Right(VatReturnObligations(obligations)) =>
-        val lastFulfilledObligation: VatReturnObligation = returnsService.getLastObligation(obligations)
-        Ok(views.html.returns.noUpcomingReturnDeadlines(Some(ReturnDeadlineViewModel(
-          due = lastFulfilledObligation.due,
-          start = lastFulfilledObligation.start,
-          end = lastFulfilledObligation.end,
-          periodKey = lastFulfilledObligation.periodKey
-        )), serviceInfoContent))
-      case Left(error) =>
-        Logger.warn("[ReturnObligationsController][fulfilledObligationsAction] error: " + error.toString)
-        InternalServerError(views.html.errors.technicalProblem())
-    }
-  }
-   */
 
   def getReturnObligationsForYear(user: User, searchYear: Int, status: Status.Value)
                                  (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ServiceResponse[VatReturnObligations]] = {

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -30,7 +30,7 @@ class SubscriptionService @Inject()(connector: VatSubscriptionConnector) {
   def getUserDetails(user: User)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[CustomerDetail]] = {
     connector.getCustomerInfo(user.vrn).map {
 
-      case Right(CustomerInformation(None, None, None, None, _, _)) => None
+      case Right(CustomerInformation(None, None, None, None, _, _, _)) => None
 
       case Right(model) =>
 

--- a/app/views/returns/submittedReturns.scala.html
+++ b/app/views/returns/submittedReturns.scala.html
@@ -60,7 +60,7 @@
                 @inactiveTab(
                   messages("submittedReturns.previousReturns"),
                   messages("submittedReturns.inactivePrevious"),
-                  controllers.routes.ReturnObligationsController.submittedReturns(model.returnYears.last - 1).url
+                  controllers.routes.SubmittedReturnsController.submittedReturns(model.returnYears.last - 1).url
                 )
               }
             </ul>

--- a/app/views/returns/vatReturnDetails.scala.html
+++ b/app/views/returns/vatReturnDetails.scala.html
@@ -57,7 +57,7 @@
         links = Map(
           appConfig.btaHomeUrl -> messages("breadcrumbs.bta"),
           appConfig.vatDetailsUrl -> messages("breadcrumbs.vat"),
-          if(vatReturnViewModel.showReturnsBreadcrumb) controllers.routes.ReturnObligationsController.submittedReturns(vatReturnViewModel.currentYear).url -> messages("submittedReturns.title")
+          if(vatReturnViewModel.showReturnsBreadcrumb) controllers.routes.SubmittedReturnsController.submittedReturns(vatReturnViewModel.currentYear).url -> messages("submittedReturns.title")
           else appConfig.vatPaymentsUrl -> messages("breadcrumbs.vatPayments")
         ),
         currentPage = returnHeading(useShortDayFormat = false).toString
@@ -66,7 +66,7 @@
 
 <section class="grid-row column-two-thirds">
     @if(user.isAgent) {
-        <a id="link-back" class="link-back" href='@controllers.routes.ReturnObligationsController.submittedReturns(vatReturnViewModel.currentYear)'>@messages("base.back")</a>
+        <a id="link-back" class="link-back" href='@controllers.routes.SubmittedReturnsController.submittedReturns(vatReturnViewModel.currentYear)'>@messages("base.back")</a>
     }
 
     <h1 class="heading-xlarge">

--- a/app/views/templates/returns/submittedReturnsTabs.scala.html
+++ b/app/views/templates/returns/submittedReturnsTabs.scala.html
@@ -25,7 +25,7 @@
     @inactiveTab(
       yearToDisplay.toString,
       messages("submittedReturns.inactiveTab", yearToDisplay.toString),
-      controllers.routes.ReturnObligationsController.submittedReturns(yearToDisplay).url
+      controllers.routes.SubmittedReturnsController.submittedReturns(yearToDisplay).url
     )
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,10 +1,10 @@
 # microservice specific routes
 
 # Get return deadlines
-GET        /return-deadlines            controllers.ReturnObligationsController.returnDeadlines
+GET        /return-deadlines            controllers.ReturnDeadlinesController.returnDeadlines
 
 # Get submitted returns for a year
-GET        /submitted/:year             controllers.ReturnObligationsController.submittedReturns(year: Int)
+GET        /submitted/:year             controllers.SubmittedReturnsController.submittedReturns(year: Int)
 
 # Get a return via the submitted returns page
 GET        /submitted/:year/:periodKey  controllers.ReturnsController.vatReturn(year: Int, periodKey: String)

--- a/it/connectors/VatSubscriptionConnectorISpec.scala
+++ b/it/connectors/VatSubscriptionConnectorISpec.scala
@@ -48,7 +48,8 @@ class VatSubscriptionConnectorISpec extends IntegrationBaseSpec {
           Some("Vatreturn"),
           Some("Cheapo Clothing"),
           hasFlatRateScheme = true,
-          Some(true)
+          Some(true),
+          Some("2018-01-01")
         ))
         private val result = await(connector.getCustomerInfo("999999999"))
 

--- a/it/pages/SubmittedReturnsPageSpec.scala
+++ b/it/pages/SubmittedReturnsPageSpec.scala
@@ -22,7 +22,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.http.Status
 import play.api.libs.ws.{WSRequest, WSResponse}
-import stubs.{AuthStub, VatObligationsStub}
+import stubs.{AuthStub, CustomerInfoStub, VatObligationsStub}
 
 class SubmittedReturnsPageSpec extends IntegrationBaseSpec {
 
@@ -48,6 +48,7 @@ class SubmittedReturnsPageSpec extends IntegrationBaseSpec {
         "return 200" in new Test {
           override def setupStubs(): StubMapping = {
             AuthStub.authorised()
+            CustomerInfoStub.stubCustomerInfo()
             obligationsStub.stub2018Obligations
           }
 
@@ -64,6 +65,7 @@ class SubmittedReturnsPageSpec extends IntegrationBaseSpec {
 
           override def setupStubs(): StubMapping = {
             AuthStub.authorised()
+            CustomerInfoStub.stubCustomerInfo()
             obligationsStub.stub2018Obligations
           }
 

--- a/it/stubs/CustomerInfoStub.scala
+++ b/it/stubs/CustomerInfoStub.scala
@@ -41,7 +41,8 @@ object CustomerInfoStub extends WireMockMethods {
       "firstName" -> "Vincent",
       "lastName" -> "Vatreturn",
       "tradingName" -> "Cheapo Clothing",
-      "isPartialMigration" -> true
+      "isPartialMigration" -> true,
+      "customerMigratedToETMPDate" -> "2018-01-01"
     ),
     "ppob" -> Json.obj(
       "address" -> Json.obj(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/test/app/RouteSpec.scala
+++ b/test/app/RouteSpec.scala
@@ -37,13 +37,13 @@ class RouteSpec extends UnitSpec with GuiceOneAppPerSuite {
 
   "The route for the list of returns" should {
     "be /vat-through-software/vat-returns/submitted/2017" in {
-      controllers.routes.ReturnObligationsController.submittedReturns(2017).url shouldBe "/vat-through-software/vat-returns/submitted/2017"
+      controllers.routes.SubmittedReturnsController.submittedReturns(2017).url shouldBe "/vat-through-software/vat-returns/submitted/2017"
     }
   }
 
   "The route for the return deadlines" should {
     "be /vat-through-software/vat-returns/return-deadlines" in {
-      controllers.routes.ReturnObligationsController.returnDeadlines().url shouldBe "/vat-through-software/vat-returns/return-deadlines"
+      controllers.routes.ReturnDeadlinesController.returnDeadlines().url shouldBe "/vat-through-software/vat-returns/return-deadlines"
     }
   }
 }

--- a/test/common/TestJson.scala
+++ b/test/common/TestJson.scala
@@ -26,7 +26,8 @@ object TestJson {
       "firstName" -> "Betty",
       "lastName" -> "Jones",
       "tradingName" -> "Cheapo Clothing",
-      "isPartialMigration" -> false
+      "isPartialMigration" -> false,
+      "customerMigratedToETMPDate" -> "2018-01-01"
     ),
     "ppob" -> Json.obj(
       "address" -> Json.obj(

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -26,6 +26,7 @@ object TestModels {
     Some("Jones"),
     Some("Cheapo Clothing"),
     hasFlatRateScheme = true,
-    Some(false)
+    Some(false),
+    Some("2018-01-01")
   )
 }

--- a/test/connectors/FinancialDataConnectorSpec.scala
+++ b/test/connectors/FinancialDataConnectorSpec.scala
@@ -19,11 +19,8 @@ package connectors
 import controllers.ControllerBaseSpec
 import mocks.MockMetricsService
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
-import services.DateService
 
 class FinancialDataConnectorSpec extends ControllerBaseSpec {
-
-  val mockDateService: DateService = mock[DateService]
 
   "FinancialDataConnector" should {
 
@@ -31,6 +28,5 @@ class FinancialDataConnectorSpec extends ControllerBaseSpec {
       val connector = new FinancialDataConnector(mock[HttpClient], mockConfig, MockMetricsService, mockDateService)
       connector.paymentsUrl("111111111") shouldEqual "/financial-transactions/vat/111111111"
     }
-
   }
 }

--- a/test/connectors/ServiceInfoConnectorSpec.scala
+++ b/test/connectors/ServiceInfoConnectorSpec.scala
@@ -30,8 +30,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ServiceInfoConnectorSpec extends ControllerBaseSpec {
 
-  val hcForPartials: VatHeaderCarrierForPartialsConverter = injector.instanceOf[VatHeaderCarrierForPartialsConverter]
-  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+  val hcForPartials: VatHeaderCarrierForPartialsConverter = app.injector.instanceOf[VatHeaderCarrierForPartialsConverter]
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
   implicit val messagesImpl: Messages = Messages(Lang("en-GB"), messages)
   val validHtml = Html("<nav>BTA LINK</nav>")
 

--- a/test/controllers/ReturnDeadlinesControllerSpec.scala
+++ b/test/controllers/ReturnDeadlinesControllerSpec.scala
@@ -18,185 +18,65 @@ package controllers
 
 import java.time.LocalDate
 
-import audit.AuditingService
-import audit.models.ExtendedAuditModel
 import common.SessionKeys
-import controllers.predicate.AuthoriseAgentWithClient
-import models.{User, _}
+import models._
 import models.errors.ObligationError
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.http.Status
-import play.api.mvc.{Request, Result}
 import play.api.test.Helpers.{charset, contentType, _}
-import play.twirl.api.Html
-import services.{DateService, EnrolmentsAuthService, ReturnsService, ServiceInfoService}
-import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual}
-import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.auth.core.{User => _, _}
-import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
 
-  val agentEnrolment = Enrolments(
-    Set(
-      Enrolment(
-        "HMRC-AS-AGENT",
-        Seq(EnrolmentIdentifier("AgentReferenceNumber", "XAIT0000000000")),
-        "Activated",
-        Some("mtd-vat-auth")
-      )
+  val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(VatReturnObligations(Seq(
+    VatReturnObligation(
+      LocalDate.parse("2017-01-01"),
+      LocalDate.parse("2017-12-31"),
+      LocalDate.parse("2018-01-31"),
+      "O",
+      None,
+      "#001"
     )
+  )))
+
+  val emptyObligations: ServiceResponse[VatReturnObligations] = Right(VatReturnObligations(Seq.empty))
+
+  def controller: ReturnDeadlinesController = new ReturnDeadlinesController(
+    messages,
+    enrolmentsAuthService,
+    mockVatReturnService,
+    mockAuthorisedController,
+    mockDateService,
+    mockServiceInfoService,
+    mockConfig,
+    mockAuditService
   )
-
-  val goodAgentEnrolments: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(new ~(
-    agentEnrolment,
-    Some(Agent)
-  ))
-
-  val goodEnrolments: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(new ~(
-    Enrolments(
-      Set(
-        Enrolment(
-          "HMRC-MTD-VAT",
-          Seq(EnrolmentIdentifier("VRN", vrn)),
-          "Active"))
-    ),
-    Some(Individual)
-  ))
-
-  private trait ReturnDeadlinesTest {
-
-    val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(
-      VatReturnObligations(
-        Seq(
-          VatReturnObligation(
-            LocalDate.parse("2017-01-01"),
-            LocalDate.parse("2017-12-31"),
-            LocalDate.parse("2018-01-31"),
-            "O",
-            None,
-            "#001"
-          )
-        )
-      )
-    )
-
-    val openObsServiceCall = true
-    val serviceInfoCall = true
-    val openObligations: Boolean = true
-    val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(goodEnrolments)
-    val agentAuthResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(goodAgentEnrolments)
-    val mockAuthConnector: AuthConnector = mock[AuthConnector]
-    val mockVatReturnService: ReturnsService = mock[ReturnsService]
-    val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
-    val mandationStatusCall: Boolean = false
-    val mandationStatusCallResponse: String = "MTDfB"
-    val mockDateService: DateService = mock[DateService]
-    val mockAuditService: AuditingService = mock[AuditingService]
-    val previousYear: Int = 201
-    val auditingExpected: Boolean = false
-    val mockEnrolmentsAuthService: EnrolmentsAuthService = new EnrolmentsAuthService(mockAuthConnector)
-    val mockAuthorisedAgentWithClient: AuthoriseAgentWithClient = new AuthoriseAgentWithClient(
-      mockEnrolmentsAuthService,
-      mockVatReturnService,
-      messages,
-      mockConfig
-    )
-
-    val mockAuthorisedController: AuthorisedController = new AuthorisedController(
-      mockEnrolmentsAuthService,
-      messages,
-      mockAuthorisedAgentWithClient,
-      mockConfig
-    )
-
-    def setup(): Any = {
-
-      (mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")).anyNumberOfTimes()
-
-      (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *, *)
-        .returns(authResult)
-        .noMoreThanOnce()
-
-      if (mandationStatusCall) {
-        (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
-          .expects("999999999", *, *)
-          .returns(Future.successful(Right(MandationStatus(mandationStatusCallResponse))))
-      }
-
-      if (openObsServiceCall) {
-        (mockVatReturnService.getOpenReturnObligations(_: User)
-        (_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, *, *)
-          .returns(exampleObligations)
-
-        (mockAuditService.extendedAudit(_: ExtendedAuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
-          .stubs(*, *, *, *)
-          .returns({})
-
-        if (authResult != agentAuthResult && serviceInfoCall) {
-          (mockServiceInfoService.getServiceInfoPartial(_: Request[_], _: ExecutionContext))
-            .expects(*, *)
-            .returns(Future.successful(Html("")))
-        }
-      }
-
-      if (!openObligations) {
-        (mockVatReturnService.getFulfilledObligations(_: LocalDate)
-        (_: User, _: HeaderCarrier, _: ExecutionContext))
-          .expects(*, *, *, *)
-          .returns(Right(VatReturnObligations(Seq.empty)))
-      }
-    }
-
-    def target: ReturnDeadlinesController = {
-      setup()
-      new ReturnDeadlinesController(
-        messages,
-        mockEnrolmentsAuthService,
-        mockVatReturnService,
-        mockAuthorisedController,
-        mockDateService,
-        mockServiceInfoService,
-        mockConfig,
-        mockAuditService)
-    }
-
-    def agentTarget: ReturnDeadlinesController = {
-      setup()
-      new ReturnDeadlinesController(
-        messages,
-        mockEnrolmentsAuthService,
-        mockVatReturnService,
-        mockAuthorisedController,
-        mockDateService,
-        mockServiceInfoService,
-        mockConfig,
-        mockAuditService)
-    }
-  }
 
   "Calling the .returnDeadlines action" when {
 
     "A user is logged in and enrolled to HMRC-MTD-VAT" should {
 
-      "return 200" in new ReturnDeadlinesTest {
-        private val result = target.returnDeadlines()(fakeRequest)
+      lazy val result = {
+        callAuthService(individualAuthResult)
+        callDateService()
+        callOpenObligations(exampleObligations)
+        callExtendedAudit
+        callServiceInfoPartialService
+        controller.returnDeadlines()(fakeRequest)
+      }
+
+      "return 200" in {
         status(result) shouldBe Status.OK
       }
 
-      "return HTML" in new ReturnDeadlinesTest {
-        private val result = target.returnDeadlines()(fakeRequest)
+      "return HTML" in {
         contentType(result) shouldBe Some("text/html")
       }
 
-      "return charset of utf-8" in new ReturnDeadlinesTest {
-        private val result = target.returnDeadlines()(fakeRequest)
+      "return charset of utf-8" in {
         charset(result) shouldBe Some("utf-8")
       }
     }
@@ -205,11 +85,21 @@ class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
 
       "mandation status is in session" should {
 
-        "return the opt-out return deadlines page" in new ReturnDeadlinesTest {
+        lazy val result = {
           mockConfig.features.submitReturnFeatures(true)
-          override val mandationStatusCall: Boolean = false
-          private val result = target.returnDeadlines()(fakeRequest.withSession("mtdVatMandationStatus" -> "Non MTDfB"))
+          callAuthService(individualAuthResult)
+          callDateService()
+          callOpenObligations(exampleObligations)
+          callExtendedAudit
+          callServiceInfoPartialService
+          controller.returnDeadlines()(fakeRequest.withSession("mtdVatMandationStatus" -> "Non MTDfB"))
+        }
+
+        "return 200" in {
           status(result) shouldBe Status.OK
+        }
+
+        "return the opt-out return deadlines page" in {
           val document: Document = Jsoup.parse(bodyOf(result))
           document.getElementById("submit-return-link").text() shouldBe "Submit VAT Return"
         }
@@ -217,17 +107,28 @@ class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
 
       "mandation status is not in session" should {
 
-        "return the opt-out return deadlines page" in new ReturnDeadlinesTest {
+        lazy val result = {
           mockConfig.features.submitReturnFeatures(true)
-          override val mandationStatusCall: Boolean = true
-          override val mandationStatusCallResponse: String = "Non MTDfB"
+          callAuthService(individualAuthResult)
+          callDateService()
+          callOpenObligations(exampleObligations)
+          callExtendedAudit
+          callServiceInfoPartialService
+          callMandationService(Right(MandationStatus("Non MTDfB")))
+          controller.returnDeadlines()(fakeRequest)
+        }
 
-          private val result = target.returnDeadlines()(fakeRequest)
-
+        "return 200" in {
           status(result) shouldBe Status.OK
+        }
+
+        "return the opt-out return deadlines page" in {
           val document: Document = Jsoup.parse(bodyOf(result))
           document.getElementById("submit-return-link").text() shouldBe "Submit VAT Return"
-          result.session.get(SessionKeys.mtdVatMandationStatus) shouldBe Some("Non MTDfB")
+        }
+
+        "put the mandation status in the session" in {
+          session(result).get(SessionKeys.mtdVatMandationStatus) shouldBe Some("Non MTDfB")
         }
       }
     }
@@ -236,13 +137,21 @@ class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
 
       "mandation status is in session" should {
 
-        "return the regular return deadlines page" in new ReturnDeadlinesTest {
+        lazy val result = {
           mockConfig.features.submitReturnFeatures(true)
-          override val mandationStatusCall: Boolean = false
+          callAuthService(individualAuthResult)
+          callDateService()
+          callOpenObligations(exampleObligations)
+          callExtendedAudit
+          callServiceInfoPartialService
+          controller.returnDeadlines()(fakeRequest.withSession("mtdVatMandationStatus" -> "MTDfB Mandated"))
+        }
 
-          private val result = target.returnDeadlines()(fakeRequest.withSession("mtdVatMandationStatus" -> "MTDfB Mandated"))
-
+        "return 200" in {
           status(result) shouldBe Status.OK
+        }
+
+        "return the regular return deadlines page" in {
           val document: Document = Jsoup.parse(bodyOf(result))
           document.getElementById("submit-return-link") shouldBe null
         }
@@ -250,89 +159,103 @@ class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
 
       "mandation status is not in session" should {
 
-        "return the regular return deadlines page" in new ReturnDeadlinesTest {
+        lazy val result = {
           mockConfig.features.submitReturnFeatures(true)
-          override val mandationStatusCall: Boolean = true
-          override val mandationStatusCallResponse: String = "MTDfB Mandated"
+          callAuthService(individualAuthResult)
+          callDateService()
+          callOpenObligations(exampleObligations)
+          callExtendedAudit
+          callServiceInfoPartialService
+          callMandationService(Right(MandationStatus("MTDfB Mandated")))
+          controller.returnDeadlines()(fakeRequest)
+        }
 
-          private val result = target.returnDeadlines()(fakeRequest)
-
+        "return 200" in {
           status(result) shouldBe Status.OK
+        }
+
+        "return the regular return deadlines page" in {
           val document: Document = Jsoup.parse(bodyOf(result))
           document.getElementById("submit-return-link") shouldBe null
+        }
 
-          result.session.get(SessionKeys.mtdVatMandationStatus) shouldBe Some("MTDfB Mandated")
+        "put the mandation status in the session " in {
+          session(result).get(SessionKeys.mtdVatMandationStatus) shouldBe Some("MTDfB Mandated")
         }
       }
     }
 
     "A user with no open obligations" should {
 
-      "return the no returns view" in new ReturnDeadlinesTest {
-        override val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(VatReturnObligations(Seq.empty))
-        override val openObligations: Boolean = false
+      lazy val result = {
+        callAuthService(individualAuthResult)
+        callDateService()
+        callOpenObligations(emptyObligations)
+        callFulfilledObligations(emptyObligations)
+        callExtendedAudit
+        callServiceInfoPartialService
+        controller.returnDeadlines()(fakeRequest)
+      }
 
-        val result: Result = await(target.returnDeadlines()(fakeRequest))
+
+      "return 200" in {
+        status(result) shouldBe Status.OK
+      }
+
+      "return the no returns view" in {
         val document: Document = Jsoup.parse(bodyOf(result))
-
         document.select("article > p:nth-child(3)").text() shouldBe
           "You do not have any returns due right now. Your next deadline will show here on the first day of your next" +
             " accounting period."
       }
     }
 
-    "the user is an agent (with agentAccess enabled)" should {
+    "the user is an agent (with agentAccess enabled)" when {
 
-      mockConfig.features.agentAccess(true)
-
-      "return 200, HTML and a charset of utf-8" in new ReturnDeadlinesTest {
-
-        override val authResult: Future[Enrolments ~ Option[AffinityGroup]] = agentAuthResult
-
-        override def setup(): Unit = {
-          super.setup()
-
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, *, *, *)
-            .returns(Future.successful(agentEnrolment))
-            .noMoreThanOnce()
-
-          (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
-            .expects(vrn, *, *)
-            .returns(Future.successful(Right(MandationStatus("Non MTDfB"))))
-        }
-
-        private val result = agentTarget.returnDeadlines()(fakeRequestWithClientsVRN)
-        status(result) shouldBe Status.OK
-        contentType(result) shouldBe Some("text/html")
-        charset(result) shouldBe Some("utf-8")
+      lazy val result = {
+        callAuthService(agentAuthResult)
+        callAuthServiceEnrolmentsOnly(Enrolments(agentEnrolment))
+        callDateService()
+        callOpenObligations(exampleObligations)
+        callExtendedAudit
+        callMandationService(Right(MandationStatus("Non MTDfB")))
+        controller.returnDeadlines()(fakeRequestWithClientsVRN)
       }
 
-      "if the client has no open obligations" should {
+      "the client has open obligations" should {
 
-        "return the no returns view" in new ReturnDeadlinesTest {
+        "return 200" in {
+          status(result) shouldBe Status.OK
+        }
 
-          override val authResult: Future[Enrolments ~ Option[AffinityGroup]] = agentAuthResult
+        "return HTML" in {
+          contentType(result) shouldBe Some("text/html")
+        }
 
-          override def setup(): Unit = {
-            super.setup()
+        "return charset of utf-8" in {
+          charset(result) shouldBe Some("utf-8")
+        }
+      }
 
-            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *, *)
-              .returns(Future.successful(agentEnrolment))
-              .noMoreThanOnce()
+      "the client has no open obligations" should {
 
-            (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
-              .expects(vrn, *, *)
-              .returns(Future.successful(Right(MandationStatus("Non MTDfB"))))
-          }
+        lazy val result = {
+          callAuthService(agentAuthResult)
+          callAuthServiceEnrolmentsOnly(Enrolments(agentEnrolment))
+          callDateService()
+          callOpenObligations(emptyObligations)
+          callFulfilledObligations(emptyObligations)
+          callExtendedAudit
+          callMandationService(Right(MandationStatus("Non MTDfB")))
+          controller.returnDeadlines()(fakeRequestWithClientsVRN)
+        }
 
-          override val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(VatReturnObligations(Seq.empty))
-          override val openObligations: Boolean = false
+        "return 200" in {
+          status(result) shouldBe Status.OK
+        }
 
-          val result: Result = await(agentTarget.returnDeadlines()(fakeRequestWithClientsVRN))
+        "return the no returns view" in {
           val document: Document = Jsoup.parse(bodyOf(result))
-
           document.select("article > p:nth-child(3)").text() shouldBe
             "You do not have any returns due right now. Your next deadline will show here on the first day of your next" +
               " accounting period."
@@ -341,70 +264,68 @@ class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
 
       "if the openObligations call fails" should {
 
-        "return an ISE" in new ReturnDeadlinesTest {
+        lazy val result = {
+          callAuthService(agentAuthResult)
+          callAuthServiceEnrolmentsOnly(Enrolments(agentEnrolment))
+          callDateService()
+          callOpenObligations(Left(ObligationError))
+          callExtendedAudit
+          callMandationService(Right(MandationStatus("Non MTDfB")))
+          controller.returnDeadlines()(fakeRequestWithClientsVRN)
+        }
 
-          override val authResult: Future[Enrolments ~ Option[AffinityGroup]] = agentAuthResult
+        "return 500" in {
+          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        }
 
-          override def setup(): Unit = {
-            super.setup()
-
-            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *, *)
-              .returns(Future.successful(agentEnrolment))
-              .noMoreThanOnce()
-
-            (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
-              .expects(vrn, *, *)
-              .returns(Future.successful(Right(MandationStatus("Non MTDfB"))))
-
-            (mockVatReturnService.getOpenReturnObligations(_: User)
-            (_: HeaderCarrier, _: ExecutionContext))
-              .expects(*, *, *)
-              .returns(exampleObligations)
-          }
-
-          override val openObsServiceCall: Boolean = false
-          override val exampleObligations: Future[ServiceResponse[Nothing]] = Left(ObligationError)
-
-          val result: Result = await(agentTarget.returnDeadlines()(fakeRequestWithClientsVRN))
+        "return the technical problem view" in {
           val document: Document = Jsoup.parse(bodyOf(result))
-
-          document.select("h1").first().text() shouldBe "Sorry, there is a problem with the service"
+          document.title shouldBe "There is a problem with the service - VAT reporting through software - GOV.UK"
         }
       }
     }
 
     "A user is not authorised" should {
 
-      "return 403 (Forbidden)" in new ReturnDeadlinesTest {
-        override val openObsServiceCall: Boolean = false
-        override val serviceInfoCall: Boolean = false
-        override val authResult: Future[Nothing] = Future.failed(InsufficientEnrolments())
-        private val result = target.returnDeadlines()(fakeRequest)
+      lazy val result = {
+        callAuthService(Future.failed(InsufficientEnrolments()))
+        callDateService()
+        controller.returnDeadlines()(fakeRequest)
+      }
+
+      "return 403 (Forbidden)" in {
         status(result) shouldBe Status.FORBIDDEN
       }
     }
 
     "A user is not authenticated" should {
 
-      "return 401 (Unauthorised)" in new ReturnDeadlinesTest {
-        override val openObsServiceCall: Boolean = false
-        override val serviceInfoCall: Boolean = false
-        override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
-        private val result = target.returnDeadlines()(fakeRequest)
+      lazy val result = {
+        callAuthService(Future.failed(MissingBearerToken()))
+        callDateService()
+        controller.returnDeadlines()(fakeRequest)
+      }
+
+      "return 401 (Unauthorised)" in {
         status(result) shouldBe Status.UNAUTHORIZED
       }
     }
 
     "the Obligations API call fails" should {
 
-      "return the technical problem view" in new ReturnDeadlinesTest {
-        override val serviceInfoCall: Boolean = false
-        override val exampleObligations: Future[ServiceResponse[Nothing]] = Left(ObligationError)
+      lazy val result = {
+        callAuthService(individualAuthResult)
+        callDateService()
+        callOpenObligations(Left(ObligationError))
+        controller.returnDeadlines()(fakeRequest)
+      }
 
-        val result: Result = await(target.returnDeadlines()(fakeRequest))
+      "return 500" in {
+        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+      }
+
+      "return the technical problem view" in {
         val document: Document = Jsoup.parse(bodyOf(result))
-
         document.title shouldBe "There is a problem with the service - VAT reporting through software - GOV.UK"
       }
     }

--- a/test/controllers/ReturnDeadlinesControllerSpec.scala
+++ b/test/controllers/ReturnDeadlinesControllerSpec.scala
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import java.time.LocalDate
+
+import audit.AuditingService
+import audit.models.ExtendedAuditModel
+import common.SessionKeys
+import controllers.predicate.AuthoriseAgentWithClient
+import models.{User, _}
+import models.errors.ObligationError
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.http.Status
+import play.api.mvc.{Request, Result}
+import play.api.test.Helpers.{charset, contentType, _}
+import play.twirl.api.Html
+import services.{DateService, EnrolmentsAuthService, ReturnsService, ServiceInfoService}
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual}
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
+import uk.gov.hmrc.auth.core.{User => _, _}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ReturnDeadlinesControllerSpec extends ControllerBaseSpec {
+
+  val agentEnrolment = Enrolments(
+    Set(
+      Enrolment(
+        "HMRC-AS-AGENT",
+        Seq(EnrolmentIdentifier("AgentReferenceNumber", "XAIT0000000000")),
+        "Activated",
+        Some("mtd-vat-auth")
+      )
+    )
+  )
+
+  val goodAgentEnrolments: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(new ~(
+    agentEnrolment,
+    Some(Agent)
+  ))
+
+  val goodEnrolments: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(new ~(
+    Enrolments(
+      Set(
+        Enrolment(
+          "HMRC-MTD-VAT",
+          Seq(EnrolmentIdentifier("VRN", vrn)),
+          "Active"))
+    ),
+    Some(Individual)
+  ))
+
+  private trait ReturnDeadlinesTest {
+
+    val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(
+      VatReturnObligations(
+        Seq(
+          VatReturnObligation(
+            LocalDate.parse("2017-01-01"),
+            LocalDate.parse("2017-12-31"),
+            LocalDate.parse("2018-01-31"),
+            "O",
+            None,
+            "#001"
+          )
+        )
+      )
+    )
+
+    val openObsServiceCall = true
+    val serviceInfoCall = true
+    val openObligations: Boolean = true
+    val authResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(goodEnrolments)
+    val agentAuthResult: Future[~[Enrolments, Option[AffinityGroup]]] = Future.successful(goodAgentEnrolments)
+    val mockAuthConnector: AuthConnector = mock[AuthConnector]
+    val mockVatReturnService: ReturnsService = mock[ReturnsService]
+    val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
+    val mandationStatusCall: Boolean = false
+    val mandationStatusCallResponse: String = "MTDfB"
+    val mockDateService: DateService = mock[DateService]
+    val mockAuditService: AuditingService = mock[AuditingService]
+    val previousYear: Int = 201
+    val auditingExpected: Boolean = false
+    val mockEnrolmentsAuthService: EnrolmentsAuthService = new EnrolmentsAuthService(mockAuthConnector)
+    val mockAuthorisedAgentWithClient: AuthoriseAgentWithClient = new AuthoriseAgentWithClient(
+      mockEnrolmentsAuthService,
+      mockVatReturnService,
+      messages,
+      mockConfig
+    )
+
+    val mockAuthorisedController: AuthorisedController = new AuthorisedController(
+      mockEnrolmentsAuthService,
+      messages,
+      mockAuthorisedAgentWithClient,
+      mockConfig
+    )
+
+    def setup(): Any = {
+
+      (mockDateService.now: () => LocalDate).stubs().returns(LocalDate.parse("2018-05-01")).anyNumberOfTimes()
+
+      (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *, *, *)
+        .returns(authResult)
+        .noMoreThanOnce()
+
+      if (mandationStatusCall) {
+        (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+          .expects("999999999", *, *)
+          .returns(Future.successful(Right(MandationStatus(mandationStatusCallResponse))))
+      }
+
+      if (openObsServiceCall) {
+        (mockVatReturnService.getOpenReturnObligations(_: User)
+        (_: HeaderCarrier, _: ExecutionContext))
+          .expects(*, *, *)
+          .returns(exampleObligations)
+
+        (mockAuditService.extendedAudit(_: ExtendedAuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
+          .stubs(*, *, *, *)
+          .returns({})
+
+        if (authResult != agentAuthResult && serviceInfoCall) {
+          (mockServiceInfoService.getServiceInfoPartial(_: Request[_], _: ExecutionContext))
+            .expects(*, *)
+            .returns(Future.successful(Html("")))
+        }
+      }
+
+      if (!openObligations) {
+        (mockVatReturnService.getFulfilledObligations(_: LocalDate)
+        (_: User, _: HeaderCarrier, _: ExecutionContext))
+          .expects(*, *, *, *)
+          .returns(Right(VatReturnObligations(Seq.empty)))
+      }
+    }
+
+    def target: ReturnDeadlinesController = {
+      setup()
+      new ReturnDeadlinesController(
+        messages,
+        mockEnrolmentsAuthService,
+        mockVatReturnService,
+        mockAuthorisedController,
+        mockDateService,
+        mockServiceInfoService,
+        mockConfig,
+        mockAuditService)
+    }
+
+    def agentTarget: ReturnDeadlinesController = {
+      setup()
+      new ReturnDeadlinesController(
+        messages,
+        mockEnrolmentsAuthService,
+        mockVatReturnService,
+        mockAuthorisedController,
+        mockDateService,
+        mockServiceInfoService,
+        mockConfig,
+        mockAuditService)
+    }
+  }
+
+  "Calling the .returnDeadlines action" when {
+
+    "A user is logged in and enrolled to HMRC-MTD-VAT" should {
+
+      "return 200" in new ReturnDeadlinesTest {
+        private val result = target.returnDeadlines()(fakeRequest)
+        status(result) shouldBe Status.OK
+      }
+
+      "return HTML" in new ReturnDeadlinesTest {
+        private val result = target.returnDeadlines()(fakeRequest)
+        contentType(result) shouldBe Some("text/html")
+      }
+
+      "return charset of utf-8" in new ReturnDeadlinesTest {
+        private val result = target.returnDeadlines()(fakeRequest)
+        charset(result) shouldBe Some("utf-8")
+      }
+    }
+
+    "for a non-MTDfB user (with the submit return feature enabled)" when {
+
+      "mandation status is in session" should {
+
+        "return the opt-out return deadlines page" in new ReturnDeadlinesTest {
+          mockConfig.features.submitReturnFeatures(true)
+          override val mandationStatusCall: Boolean = false
+          private val result = target.returnDeadlines()(fakeRequest.withSession("mtdVatMandationStatus" -> "Non MTDfB"))
+          status(result) shouldBe Status.OK
+          val document: Document = Jsoup.parse(bodyOf(result))
+          document.getElementById("submit-return-link").text() shouldBe "Submit VAT Return"
+        }
+      }
+
+      "mandation status is not in session" should {
+
+        "return the opt-out return deadlines page" in new ReturnDeadlinesTest {
+          mockConfig.features.submitReturnFeatures(true)
+          override val mandationStatusCall: Boolean = true
+          override val mandationStatusCallResponse: String = "Non MTDfB"
+
+          private val result = target.returnDeadlines()(fakeRequest)
+
+          status(result) shouldBe Status.OK
+          val document: Document = Jsoup.parse(bodyOf(result))
+          document.getElementById("submit-return-link").text() shouldBe "Submit VAT Return"
+          result.session.get(SessionKeys.mtdVatMandationStatus) shouldBe Some("Non MTDfB")
+        }
+      }
+    }
+
+    "for an MTDfB user (with the submit return feature enabled)" when {
+
+      "mandation status is in session" should {
+
+        "return the regular return deadlines page" in new ReturnDeadlinesTest {
+          mockConfig.features.submitReturnFeatures(true)
+          override val mandationStatusCall: Boolean = false
+
+          private val result = target.returnDeadlines()(fakeRequest.withSession("mtdVatMandationStatus" -> "MTDfB Mandated"))
+
+          status(result) shouldBe Status.OK
+          val document: Document = Jsoup.parse(bodyOf(result))
+          document.getElementById("submit-return-link") shouldBe null
+        }
+      }
+
+      "mandation status is not in session" should {
+
+        "return the regular return deadlines page" in new ReturnDeadlinesTest {
+          mockConfig.features.submitReturnFeatures(true)
+          override val mandationStatusCall: Boolean = true
+          override val mandationStatusCallResponse: String = "MTDfB Mandated"
+
+          private val result = target.returnDeadlines()(fakeRequest)
+
+          status(result) shouldBe Status.OK
+          val document: Document = Jsoup.parse(bodyOf(result))
+          document.getElementById("submit-return-link") shouldBe null
+
+          result.session.get(SessionKeys.mtdVatMandationStatus) shouldBe Some("MTDfB Mandated")
+        }
+      }
+    }
+
+    "A user with no open obligations" should {
+
+      "return the no returns view" in new ReturnDeadlinesTest {
+        override val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(VatReturnObligations(Seq.empty))
+        override val openObligations: Boolean = false
+
+        val result: Result = await(target.returnDeadlines()(fakeRequest))
+        val document: Document = Jsoup.parse(bodyOf(result))
+
+        document.select("article > p:nth-child(3)").text() shouldBe
+          "You do not have any returns due right now. Your next deadline will show here on the first day of your next" +
+            " accounting period."
+      }
+    }
+
+    "the user is an agent (with agentAccess enabled)" should {
+
+      mockConfig.features.agentAccess(true)
+
+      "return 200, HTML and a charset of utf-8" in new ReturnDeadlinesTest {
+
+        override val authResult: Future[Enrolments ~ Option[AffinityGroup]] = agentAuthResult
+
+        override def setup(): Unit = {
+          super.setup()
+
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, *, *, *)
+            .returns(Future.successful(agentEnrolment))
+            .noMoreThanOnce()
+
+          (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+            .expects(vrn, *, *)
+            .returns(Future.successful(Right(MandationStatus("Non MTDfB"))))
+        }
+
+        private val result = agentTarget.returnDeadlines()(fakeRequestWithClientsVRN)
+        status(result) shouldBe Status.OK
+        contentType(result) shouldBe Some("text/html")
+        charset(result) shouldBe Some("utf-8")
+      }
+
+      "if the client has no open obligations" should {
+
+        "return the no returns view" in new ReturnDeadlinesTest {
+
+          override val authResult: Future[Enrolments ~ Option[AffinityGroup]] = agentAuthResult
+
+          override def setup(): Unit = {
+            super.setup()
+
+            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+              .expects(*, *, *, *)
+              .returns(Future.successful(agentEnrolment))
+              .noMoreThanOnce()
+
+            (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+              .expects(vrn, *, *)
+              .returns(Future.successful(Right(MandationStatus("Non MTDfB"))))
+          }
+
+          override val exampleObligations: Future[ServiceResponse[VatReturnObligations]] = Right(VatReturnObligations(Seq.empty))
+          override val openObligations: Boolean = false
+
+          val result: Result = await(agentTarget.returnDeadlines()(fakeRequestWithClientsVRN))
+          val document: Document = Jsoup.parse(bodyOf(result))
+
+          document.select("article > p:nth-child(3)").text() shouldBe
+            "You do not have any returns due right now. Your next deadline will show here on the first day of your next" +
+              " accounting period."
+        }
+      }
+
+      "if the openObligations call fails" should {
+
+        "return an ISE" in new ReturnDeadlinesTest {
+
+          override val authResult: Future[Enrolments ~ Option[AffinityGroup]] = agentAuthResult
+
+          override def setup(): Unit = {
+            super.setup()
+
+            (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+              .expects(*, *, *, *)
+              .returns(Future.successful(agentEnrolment))
+              .noMoreThanOnce()
+
+            (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+              .expects(vrn, *, *)
+              .returns(Future.successful(Right(MandationStatus("Non MTDfB"))))
+
+            (mockVatReturnService.getOpenReturnObligations(_: User)
+            (_: HeaderCarrier, _: ExecutionContext))
+              .expects(*, *, *)
+              .returns(exampleObligations)
+          }
+
+          override val openObsServiceCall: Boolean = false
+          override val exampleObligations: Future[ServiceResponse[Nothing]] = Left(ObligationError)
+
+          val result: Result = await(agentTarget.returnDeadlines()(fakeRequestWithClientsVRN))
+          val document: Document = Jsoup.parse(bodyOf(result))
+
+          document.select("h1").first().text() shouldBe "Sorry, there is a problem with the service"
+        }
+      }
+    }
+
+    "A user is not authorised" should {
+
+      "return 403 (Forbidden)" in new ReturnDeadlinesTest {
+        override val openObsServiceCall: Boolean = false
+        override val serviceInfoCall: Boolean = false
+        override val authResult: Future[Nothing] = Future.failed(InsufficientEnrolments())
+        private val result = target.returnDeadlines()(fakeRequest)
+        status(result) shouldBe Status.FORBIDDEN
+      }
+    }
+
+    "A user is not authenticated" should {
+
+      "return 401 (Unauthorised)" in new ReturnDeadlinesTest {
+        override val openObsServiceCall: Boolean = false
+        override val serviceInfoCall: Boolean = false
+        override val authResult: Future[Nothing] = Future.failed(MissingBearerToken())
+        private val result = target.returnDeadlines()(fakeRequest)
+        status(result) shouldBe Status.UNAUTHORIZED
+      }
+    }
+
+    "the Obligations API call fails" should {
+
+      "return the technical problem view" in new ReturnDeadlinesTest {
+        override val serviceInfoCall: Boolean = false
+        override val exampleObligations: Future[ServiceResponse[Nothing]] = Left(ObligationError)
+
+        val result: Result = await(target.returnDeadlines()(fakeRequest))
+        val document: Document = Jsoup.parse(bodyOf(result))
+
+        document.title shouldBe "There is a problem with the service - VAT reporting through software - GOV.UK"
+      }
+    }
+  }
+}

--- a/test/controllers/SubmittedReturnsControllerSpec.scala
+++ b/test/controllers/SubmittedReturnsControllerSpec.scala
@@ -47,8 +47,8 @@ class SubmittedReturnsControllerSpec extends ControllerBaseSpec {
     )
   )
   val emptyObligations: ServiceResponse[VatReturnObligations] = Right(VatReturnObligations(Seq.empty))
-
   val previousYear: Int = 2017
+  implicit val migrationDate: Option[String] = None
 
   def controller: SubmittedReturnsController = new SubmittedReturnsController(
     messages,
@@ -57,6 +57,7 @@ class SubmittedReturnsControllerSpec extends ControllerBaseSpec {
     mockAuthorisedController,
     mockDateService,
     mockServiceInfoService,
+    mockSubscriptionService,
     mockConfig,
     mockAuditService
   )

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -21,12 +21,14 @@ import java.time.LocalDate
 import audit.AuditingService
 import audit.models.{AuditModel, ExtendedAuditModel}
 import config.AppConfig
+import connectors.{VatObligationsConnector, VatSubscriptionConnector}
+import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
 import controllers.predicate.AuthoriseAgentWithClient
 import controllers.AuthorisedController
+import models.Obligation.Status
 import models.customer.CustomerDetail
 import models.payments.Payment
 import models.{Obligation, _}
-import org.scalamock.handlers._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -53,6 +55,8 @@ trait MockAuth extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterEach
   val mockAuditService: AuditingService = mock[AuditingService]
   val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
   val mockSubscriptionService: SubscriptionService = mock[SubscriptionService]
+  val mockVatObligationsConnector: VatObligationsConnector = mock[VatObligationsConnector]
+  val mockVatSubscriptionConnector: VatSubscriptionConnector = mock[VatSubscriptionConnector]
 
   val enrolmentsAuthService: EnrolmentsAuthService = new EnrolmentsAuthService(mockAuthConnector)
 
@@ -70,89 +74,90 @@ trait MockAuth extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterEach
     mockConfig
   )
 
-  def callDateService(response: LocalDate = LocalDate.parse("2018-05-01")): CallHandler0[LocalDate] =
+  def callDateService(response: LocalDate = LocalDate.parse("2018-05-01")): Any =
     (mockDateService.now: () => LocalDate)
       .stubs()
       .returns(response)
 
-  def callMandationService(response: ServiceResponse[MandationStatus]):
-  CallHandler3[String, HeaderCarrier, ExecutionContext, Future[ServiceResponse[MandationStatus]]] =
+  def callMandationService(response: ServiceResponse[MandationStatus]): Any =
     (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
     .expects(*, *, *)
     .returns(Future.successful(response))
 
-  def callOpenObligationsForYear(response: ServiceResponse[VatReturnObligations]):
-  CallHandler5[User, Int, Obligation.Status.Value, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturnObligations]]] =
+  def callOpenObligationsForYear(response: ServiceResponse[VatReturnObligations]): Any =
     (mockVatReturnService.getReturnObligationsForYear(_: User, _: Int, _: Obligation.Status.Value)
-    (_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, *, *, *, *)
+    (_: HeaderCarrier, _: ExecutionContext, _: Option[String]))
+      .expects(*, *, *, *, *, *)
       .returns(Future.successful(response))
 
-  def callOpenObligations(response: ServiceResponse[VatReturnObligations]):
-  CallHandler3[User, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturnObligations]]] =
+  def callOpenObligations(response: ServiceResponse[VatReturnObligations]): Any =
     (mockVatReturnService.getOpenReturnObligations(_: User)(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *)
       .returns(Future.successful(response))
 
-  def callFulfilledObligations(response: ServiceResponse[VatReturnObligations]):
-  CallHandler4[LocalDate, User, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturnObligations]]] =
+  def callFulfilledObligations(response: ServiceResponse[VatReturnObligations]): Any =
     (mockVatReturnService.getFulfilledObligations(_: LocalDate)(_: User, _: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)
       .returns(Future.successful(response))
 
-  def callVatReturn(response: ServiceResponse[VatReturn]):
-  CallHandler4[User, String, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturn]]] =
+  def callVatReturn(response: ServiceResponse[VatReturn]): Any =
     (mockVatReturnService.getVatReturn(_: User, _: String)(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)
       .returns(Future.successful(response))
 
-  def callObligationWithMatchingPeriodKey(response: Option[VatReturnObligation]):
-  CallHandler5[User, Int, String, HeaderCarrier, ExecutionContext, Future[Option[VatReturnObligation]]] =
-    (mockVatReturnService.getObligationWithMatchingPeriodKey(_: User, _: Int, _: String)(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, *, *, *, *)
+  def callObligationWithMatchingPeriodKey(response: Option[VatReturnObligation]): Any =
+    (mockVatReturnService.getObligationWithMatchingPeriodKey(_: User, _: Int, _: String)(_: HeaderCarrier, _: ExecutionContext, _: Option[String]))
+      .expects(*, *, *, *, *, *)
       .returns(Future.successful(response))
 
-  def callVatReturnPayment(response: Option[Payment]):
-  CallHandler5[User, String, Option[Int], HeaderCarrier, ExecutionContext, Future[Option[Payment]]] =
+  def callVatReturnPayment(response: Option[Payment]): Any =
     (mockVatReturnService.getPayment(_: User, _: String, _: Option[Int])(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *, *)
       .returns(response)
 
-  def callExtendedAudit: CallHandler4[ExtendedAuditModel, String, HeaderCarrier, ExecutionContext, Unit] =
+  def callExtendedAudit: Any =
     (mockAuditService.extendedAudit(_: ExtendedAuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
       .stubs(*, *, *, *)
       .returns({})
 
-  def callAudit: CallHandler4[AuditModel, String, HeaderCarrier, ExecutionContext, Unit] =
+  def callAudit: Any =
     (mockAuditService.audit(_: AuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
       .stubs(*, *, *, *)
       .returns({})
 
-  def callServiceInfoPartialService: CallHandler2[Request[_], ExecutionContext, Future[Html]] =
+  def callServiceInfoPartialService: Any =
     (mockServiceInfoService.getServiceInfoPartial(_: Request[_], _: ExecutionContext))
       .expects(*, *)
       .returns(Future.successful(Html("")))
 
-  def callAuthService(response: Future[~[Enrolments, Option[AffinityGroup]]]):
-  CallHandler4[Predicate, Retrieval[Enrolments ~ Option[AffinityGroup]], HeaderCarrier, ExecutionContext, Future[Enrolments ~ Option[AffinityGroup]]] =
+  def callAuthService(response: Future[~[Enrolments, Option[AffinityGroup]]]): Any =
     (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)
       .returns(response)
 
-  def callAuthServiceEnrolmentsOnly(response: Enrolments):
-  CallHandler4[Predicate, Retrieval[Enrolments], HeaderCarrier, ExecutionContext, Future[Enrolments]] =
+  def callAuthServiceEnrolmentsOnly(response: Enrolments): Any =
     (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)
       .returns(Future.successful(response))
 
-  def callSubscriptionService(response: Option[CustomerDetail]):
-  CallHandler3[User, HeaderCarrier, ExecutionContext, Future[Option[CustomerDetail]]] =
+  def callSubscriptionService(response: Option[CustomerDetail]): Any =
     (mockSubscriptionService.getUserDetails(_: User)(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *)
       .returns(Future.successful(response))
 
-  def callConstructReturnDetailsModel(response: VatReturnDetails): CallHandler2[VatReturn, Option[Payment], VatReturnDetails] =
+  def callSubscriptionConnector(response: HttpGetResult[CustomerInformation]): Any =
+    (mockVatSubscriptionConnector.getCustomerInfo(_: String)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *)
+      .returns(Future.successful(response))
+
+  def callConstructReturnDetailsModel(response: VatReturnDetails): Any =
     (mockVatReturnService.constructReturnDetailsModel(_: VatReturn, _: Option[Payment]))
       .expects(*, *)
       .returns(response)
+
+  def callObligationsConnector(response: HttpGetResult[VatReturnObligations]): Any =
+    (mockVatObligationsConnector.getVatReturnObligations(_: String, _: Option[LocalDate], _: Option[LocalDate], _: Status.Value)
+    (_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *, *, *)
+      .returns(Future.successful(response))
 }

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks
+
+import java.time.LocalDate
+
+import audit.AuditingService
+import audit.models.{AuditModel, ExtendedAuditModel}
+import config.AppConfig
+import controllers.predicate.AuthoriseAgentWithClient
+import controllers.AuthorisedController
+import models.customer.CustomerDetail
+import models.payments.Payment
+import models.{Obligation, _}
+import org.scalamock.handlers._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.MessagesApi
+import play.api.mvc.Request
+import play.twirl.api.Html
+import services._
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
+import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector, Enrolments}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockAuth extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterEach with MockFactory {
+
+  lazy val messages: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit val mockConfig: AppConfig = new MockAppConfig(app.configuration)
+
+  val mockAuthConnector: AuthConnector = mock[AuthConnector]
+  val mockVatReturnService: ReturnsService = mock[ReturnsService]
+  val mockDateService: DateService = mock[DateService]
+  val mockAuditService: AuditingService = mock[AuditingService]
+  val mockServiceInfoService: ServiceInfoService = mock[ServiceInfoService]
+  val mockSubscriptionService: SubscriptionService = mock[SubscriptionService]
+
+  val enrolmentsAuthService: EnrolmentsAuthService = new EnrolmentsAuthService(mockAuthConnector)
+
+  val mockAuthorisedAgentWithClient: AuthoriseAgentWithClient = new AuthoriseAgentWithClient(
+    enrolmentsAuthService,
+    mockVatReturnService,
+    messages,
+    mockConfig
+  )
+
+  val mockAuthorisedController: AuthorisedController = new AuthorisedController(
+    enrolmentsAuthService,
+    messages,
+    mockAuthorisedAgentWithClient,
+    mockConfig
+  )
+
+  def callDateService(response: LocalDate = LocalDate.parse("2018-05-01")): CallHandler0[LocalDate] =
+    (mockDateService.now: () => LocalDate)
+      .stubs()
+      .returns(response)
+
+  def callMandationService(response: ServiceResponse[MandationStatus]):
+  CallHandler3[String, HeaderCarrier, ExecutionContext, Future[ServiceResponse[MandationStatus]]] =
+    (mockVatReturnService.getMandationStatus(_: String)(_: HeaderCarrier, _: ExecutionContext))
+    .expects(*, *, *)
+    .returns(Future.successful(response))
+
+  def callOpenObligationsForYear(response: ServiceResponse[VatReturnObligations]):
+  CallHandler5[User, Int, Obligation.Status.Value, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturnObligations]]] =
+    (mockVatReturnService.getReturnObligationsForYear(_: User, _: Int, _: Obligation.Status.Value)
+    (_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *, *)
+      .returns(Future.successful(response))
+
+  def callOpenObligations(response: ServiceResponse[VatReturnObligations]):
+  CallHandler3[User, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturnObligations]]] =
+    (mockVatReturnService.getOpenReturnObligations(_: User)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *)
+      .returns(Future.successful(response))
+
+  def callFulfilledObligations(response: ServiceResponse[VatReturnObligations]):
+  CallHandler4[LocalDate, User, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturnObligations]]] =
+    (mockVatReturnService.getFulfilledObligations(_: LocalDate)(_: User, _: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *)
+      .returns(Future.successful(response))
+
+  def callVatReturn(response: ServiceResponse[VatReturn]):
+  CallHandler4[User, String, HeaderCarrier, ExecutionContext, Future[ServiceResponse[VatReturn]]] =
+    (mockVatReturnService.getVatReturn(_: User, _: String)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *)
+      .returns(Future.successful(response))
+
+  def callObligationWithMatchingPeriodKey(response: Option[VatReturnObligation]):
+  CallHandler5[User, Int, String, HeaderCarrier, ExecutionContext, Future[Option[VatReturnObligation]]] =
+    (mockVatReturnService.getObligationWithMatchingPeriodKey(_: User, _: Int, _: String)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *, *)
+      .returns(Future.successful(response))
+
+  def callVatReturnPayment(response: Option[Payment]):
+  CallHandler5[User, String, Option[Int], HeaderCarrier, ExecutionContext, Future[Option[Payment]]] =
+    (mockVatReturnService.getPayment(_: User, _: String, _: Option[Int])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *, *)
+      .returns(response)
+
+  def callExtendedAudit: CallHandler4[ExtendedAuditModel, String, HeaderCarrier, ExecutionContext, Unit] =
+    (mockAuditService.extendedAudit(_: ExtendedAuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
+      .stubs(*, *, *, *)
+      .returns({})
+
+  def callAudit: CallHandler4[AuditModel, String, HeaderCarrier, ExecutionContext, Unit] =
+    (mockAuditService.audit(_: AuditModel, _: String)(_: HeaderCarrier, _: ExecutionContext))
+      .stubs(*, *, *, *)
+      .returns({})
+
+  def callServiceInfoPartialService: CallHandler2[Request[_], ExecutionContext, Future[Html]] =
+    (mockServiceInfoService.getServiceInfoPartial(_: Request[_], _: ExecutionContext))
+      .expects(*, *)
+      .returns(Future.successful(Html("")))
+
+  def callAuthService(response: Future[~[Enrolments, Option[AffinityGroup]]]):
+  CallHandler4[Predicate, Retrieval[Enrolments ~ Option[AffinityGroup]], HeaderCarrier, ExecutionContext, Future[Enrolments ~ Option[AffinityGroup]]] =
+    (mockAuthConnector.authorise(_: Predicate, _: Retrieval[~[Enrolments, Option[AffinityGroup]]])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *)
+      .returns(response)
+
+  def callAuthServiceEnrolmentsOnly(response: Enrolments):
+  CallHandler4[Predicate, Retrieval[Enrolments], HeaderCarrier, ExecutionContext, Future[Enrolments]] =
+    (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *, *)
+      .returns(Future.successful(response))
+
+  def callSubscriptionService(response: Option[CustomerDetail]):
+  CallHandler3[User, HeaderCarrier, ExecutionContext, Future[Option[CustomerDetail]]] =
+    (mockSubscriptionService.getUserDetails(_: User)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*, *, *)
+      .returns(Future.successful(response))
+
+  def callConstructReturnDetailsModel(response: VatReturnDetails): CallHandler2[VatReturn, Option[Payment], VatReturnDetails] =
+    (mockVatReturnService.constructReturnDetailsModel(_: VatReturn, _: Option[Payment]))
+      .expects(*, *)
+      .returns(response)
+}

--- a/test/services/ServiceInfoServiceSpec.scala
+++ b/test/services/ServiceInfoServiceSpec.scala
@@ -27,7 +27,7 @@ class ServiceInfoServiceSpec extends ControllerBaseSpec {
 
   val mockConnector: ServiceInfoConnector = mock[ServiceInfoConnector]
   val service: ServiceInfoService = new ServiceInfoService(mockConnector)
-  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
 
   val validHtml = Html("<nav>BTA LINK</nav>")
 

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -20,7 +20,7 @@ import connectors.VatSubscriptionConnector
 import controllers.ControllerBaseSpec
 import models.customer.CustomerDetail
 import models.errors.BadRequestError
-import models.{CustomerInformation, User, customer}
+import models.{CustomerInformation, User}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits._
@@ -48,7 +48,8 @@ class SubscriptionServiceSpec extends ControllerBaseSpec {
           Some("Smith"),
           Some("My trading name"),
           hasFlatRateSchemeYes,
-          Some(true)
+          Some(true),
+          Some("2018-01-01")
         )
 
         (mockConnector.getCustomerInfo(_: String)(_: HeaderCarrier, _: ExecutionContext))
@@ -70,7 +71,8 @@ class SubscriptionServiceSpec extends ControllerBaseSpec {
           Some("Smith"),
           None,
           hasFlatRateSchemeNo,
-          Some(false)
+          Some(false),
+          Some("2018-01-01")
         )
 
         (mockConnector.getCustomerInfo(_: String)(_: HeaderCarrier, _: ExecutionContext))
@@ -92,7 +94,8 @@ class SubscriptionServiceSpec extends ControllerBaseSpec {
           Some("Smith"),
           None,
           hasFlatRateSchemeNo,
-          Some(false)
+          Some(false),
+          Some("2018-01-01")
         )
 
         (mockConnector.getCustomerInfo(_: String)(_: HeaderCarrier, _: ExecutionContext))
@@ -114,7 +117,8 @@ class SubscriptionServiceSpec extends ControllerBaseSpec {
           None,
           None,
           hasFlatRateSchemeNo,
-          Some(true)
+          Some(true),
+          Some("2018-01-01")
         )
 
         (mockConnector.getCustomerInfo(_: String)(_: HeaderCarrier, _: ExecutionContext))
@@ -137,6 +141,7 @@ class SubscriptionServiceSpec extends ControllerBaseSpec {
           Some("Smith"),
           None,
           hasFlatRateSchemeNo,
+          None,
           None
         )
 

--- a/test/views/SubmittedReturnsViewSpec.scala
+++ b/test/views/SubmittedReturnsViewSpec.scala
@@ -247,9 +247,9 @@ class SubmittedReturnsViewSpec extends ViewBaseSpec {
           elementText(Selectors.tabTwoHiddenText) shouldBe "View returns from 2019"
         }
 
-        s"contain the correct link to ${controllers.routes.ReturnObligationsController.submittedReturns(2019)}" in {
+        s"contain the correct link to ${controllers.routes.SubmittedReturnsController.submittedReturns(2019)}" in {
           element(Selectors.tabTwo).select("a").attr("href") shouldBe
-            controllers.routes.ReturnObligationsController.submittedReturns(2019).url
+            controllers.routes.SubmittedReturnsController.submittedReturns(2019).url
         }
 
       }
@@ -326,9 +326,9 @@ class SubmittedReturnsViewSpec extends ViewBaseSpec {
           elementText(Selectors.tabTwoHiddenText) shouldBe "View returns from 2019"
         }
 
-        s"contain the correct link to ${controllers.routes.ReturnObligationsController.submittedReturns(2019)}" in {
+        s"contain the correct link to ${controllers.routes.SubmittedReturnsController.submittedReturns(2019)}" in {
           element(Selectors.tabTwo).select("a").attr("href") shouldBe
-            controllers.routes.ReturnObligationsController.submittedReturns(2019).url
+            controllers.routes.SubmittedReturnsController.submittedReturns(2019).url
         }
 
       }
@@ -343,9 +343,9 @@ class SubmittedReturnsViewSpec extends ViewBaseSpec {
           elementText(Selectors.tabThreeHiddenText) shouldBe "View returns from 2018"
         }
 
-        s"contain the correct link to ${controllers.routes.ReturnObligationsController.submittedReturns(2018)}" in {
+        s"contain the correct link to ${controllers.routes.SubmittedReturnsController.submittedReturns(2018)}" in {
           element(Selectors.tabThree).select("a").attr("href") shouldBe
-            controllers.routes.ReturnObligationsController.submittedReturns(2018).url
+            controllers.routes.SubmittedReturnsController.submittedReturns(2018).url
         }
 
       }
@@ -470,9 +470,9 @@ class SubmittedReturnsViewSpec extends ViewBaseSpec {
             elementText(Selectors.tabTwo) should include("Previous returns")
           }
 
-          s"contain the correct link to ${controllers.routes.ReturnObligationsController.submittedReturns(2017)}" in {
+          s"contain the correct link to ${controllers.routes.SubmittedReturnsController.submittedReturns(2017)}" in {
             element(Selectors.tabTwo).select("a").attr("href") shouldBe
-              controllers.routes.ReturnObligationsController.submittedReturns(2017).url
+              controllers.routes.SubmittedReturnsController.submittedReturns(2017).url
           }
         }
       }
@@ -591,9 +591,9 @@ class SubmittedReturnsViewSpec extends ViewBaseSpec {
           elementText(Selectors.tabThree) should include("Previous returns")
         }
 
-        s"contain the correct link to ${controllers.routes.ReturnObligationsController.submittedReturns(2018)}" in {
+        s"contain the correct link to ${controllers.routes.SubmittedReturnsController.submittedReturns(2018)}" in {
           element(Selectors.tabThree).select("a").attr("href") shouldBe
-            controllers.routes.ReturnObligationsController.submittedReturns(2018).url
+            controllers.routes.SubmittedReturnsController.submittedReturns(2018).url
         }
       }
     }

--- a/test/views/VatReturnDetailsViewSpec.scala
+++ b/test/views/VatReturnDetailsViewSpec.scala
@@ -137,9 +137,9 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
         elementText(Selectors.previousPageBreadcrumb) shouldBe "Submitted returns"
       }
 
-      s"link to ${controllers.routes.ReturnObligationsController.submittedReturns(currentYear).url}" in {
+      s"link to ${controllers.routes.SubmittedReturnsController.submittedReturns(currentYear).url}" in {
         element(Selectors.previousPageBreadcrumbLink).attr("href") shouldBe
-          controllers.routes.ReturnObligationsController.submittedReturns(currentYear).url
+          controllers.routes.SubmittedReturnsController.submittedReturns(currentYear).url
       }
 
       "have the correct current page text containing the obligation dates" in {


### PR DESCRIPTION
Due to the difficult-to-split nature of this PR it has also been bundled with the refactor of some controllers and their tests (BTAT-6382). The bulk of this work was around diving the ReturnObligationsController into ReturnDeadlinesController and SubmittedReturnsController, as well as creating common mock functions to make the unit tests a little easier to follow.