### PR TITLE
BTAT-6701 Updated 9 box HTML to use definition lists for the box rows

### DIFF
--- a/app/views/returns/vatReturnDetails.scala.html
+++ b/app/views/returns/vatReturnDetails.scala.html
@@ -25,11 +25,11 @@
 @(vatReturnViewModel: VatReturnViewModel, serviceInfoContent: Html = HtmlFormat.empty)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig, lang: Lang, user: User)
 
 @hiddenHelpTextContent = {
- @if(vatReturnViewModel.isOptOutMtdVatUser) {
-<p>@messages("yourVatReturn.helpLineOptOut")</p>
-} else {
-  <p>@messages("yourVatReturn.helpLine")</p>
-}
+  @if(vatReturnViewModel.isOptOutMtdVatUser) {
+    <p>@messages("yourVatReturn.helpLineOptOut")</p>
+  } else {
+    <p>@messages("yourVatReturn.helpLine")</p>
+  }
   <ul class="list list-bullet">
     <li>@messages("yourVatReturn.bullet1")</li>
     <li>@messages("yourVatReturn.bullet2")</li>
@@ -92,83 +92,84 @@
       <h2 class="heading-medium">@entityName</h2>
     }
 
-    <section class="form-group divider--bottom">
+    <section>
       <h3 class="bold-small form-group">@messages("yourVatReturn.vatDetails")</h3>
-      <div class="form-group">
-        <div class="grid-row" id="box-one">
-          <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxOne")</div>
-          <div class="column-one-half form-hint">@messages("yourVatReturn.boxOneDescription")</div>
-          <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatDueSales)</div>
-        </div>
-        <div class="grid-row" id="box-two">
-          <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxTwo")</div>
-          <div class="column-one-half form-hint">@messages("yourVatReturn.boxTwoDescription")</div>
-          <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatDueAcquisitions)</div>
-        </div>
-      </div>
-      <div class="form-group">
-        <div class="grid-row" id="box-three">
-          <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxThree")</div>
-          <div class="column-one-half form-hint">@messages("yourVatReturn.boxThreeDescription")</div>
-          <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalVatDue)</div>
-        </div>
-        <div class="grid-row" id="box-four">
-          <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxFour")</div>
-          <div class="column-one-half form-hint">@messages("yourVatReturn.boxFourDescription")</div>
-          <div class="column-one-quarter form-hint text--right" style="white-space:nowrap">
-            <span aria-hidden="true">&minus;</span>
-            @displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatReclaimedCurrentPeriod.abs)
+      <dl class="form-group divider--bottom">
+        <div class="form-group">
+          <div class="grid-row" id="box-one">
+            <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxOne")</dt>
+            <dd class="column-one-half form-hint">@messages("yourVatReturn.boxOneDescription")</dd>
+            <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatDueSales)</dd>
+          </div>
+          <div class="grid-row" id="box-two">
+            <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxTwo")</dt>
+            <dd class="column-one-half form-hint">@messages("yourVatReturn.boxTwoDescription")</dd>
+            <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatDueAcquisitions)</dd>
           </div>
         </div>
-      </div>
-      <div class="form-group">
-        <div class="grid-row" id="box-five">
-          <div class="column-one-quarter"><strong class="bold-small">@messages("yourVatReturn.boxFive")</strong></div>
-          <div class="column-one-half">
-            <strong class="bold-small">
-              @messages("yourVatReturn.returnTotal")
-            </strong>
+        <div class="form-group">
+          <div class="grid-row" id="box-three">
+            <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxThree")</dt>
+            <dd class="column-one-half form-hint">@messages("yourVatReturn.boxThreeDescription")</dd>
+            <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalVatDue)</dd>
           </div>
-          <div class="column-one-quarter text--right">
-            <strong class="bold-small">
-              <span class="visually-hidden">
-                @messages("yourVatReturn.boxFiveContext", displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalVatDue), displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatReclaimedCurrentPeriod))
-              </span>
-              @displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.netVatDue)
-            </strong>
+          <div class="grid-row" id="box-four">
+            <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxFour")</dt>
+            <dd class="column-one-half form-hint">@messages("yourVatReturn.boxFourDescription")</dd>
+            <dd class="column-one-quarter form-hint text--right" style="white-space:nowrap">
+              <span aria-hidden="true">&minus;</span>
+              @displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatReclaimedCurrentPeriod.abs)
+            </dd>
           </div>
         </div>
-      </div>
+        <div class="form-group">
+          <div class="grid-row" id="box-five">
+            <dt class="column-one-quarter"><strong class="bold-small">@messages("yourVatReturn.boxFive")</strong></dt>
+            <dd class="column-one-half">
+              <strong class="bold-small">@messages("yourVatReturn.returnTotal")</strong>
+            </dd>
+            <dd class="column-one-quarter text--right">
+              <strong class="bold-small">
+                <span class="visually-hidden">
+                  @messages("yourVatReturn.boxFiveContext", displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalVatDue), displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.vatReclaimedCurrentPeriod))
+                </span>
+                @displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.netVatDue)
+              </strong>
+            </dd>
+          </div>
+        </div>
+      </dl>
     </section>
 
-    <section class="form-group">
+    <section>
       <h3 class="bold-small form-group">@messages("yourVatReturn.additionalInfo")</h3>
+      <dl class="form-group">
+        <div class="grid-row" id="box-six">
+          <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxSix")</dt>
+          @if(vatReturnViewModel.hasFlatRateScheme) {
+            <dd class="column-one-half form-hint">@messages("yourVatReturn.boxSixFlatRate")</dd>
+          } else {
+            <dd class="column-one-half form-hint">@messages("yourVatReturn.boxSixNoFlatRate")</dd>
+          }
 
-      <div class="grid-row" id="box-six">
-        <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxSix")</div>
-        @if(vatReturnViewModel.hasFlatRateScheme) {
-          <div class="column-one-half form-hint">@messages("yourVatReturn.boxSixFlatRate")</div>
-        } else {
-          <div class="column-one-half form-hint">@messages("yourVatReturn.boxSixNoFlatRate")</div>
-        }
-
-        <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalValueSalesExVAT)</div>
-      </div>
-      <div class="grid-row" id="box-seven">
-        <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxSeven")</div>
-        <div class="column-one-half form-hint">@messages("yourVatReturn.boxSevenDescription")</div>
-        <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalValuePurchasesExVAT)</div>
-      </div>
-      <div class="grid-row" id="box-eight">
-        <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxEight")</div>
-        <div class="column-one-half form-hint">@messages("yourVatReturn.boxEightDescription")</div>
-        <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalValueGoodsSuppliedExVAT)</div>
-      </div>
-      <div class="grid-row" id="box-nine">
-        <div class="column-one-quarter form-hint">@messages("yourVatReturn.boxNine")</div>
-        <div class="column-one-half form-hint">@messages("yourVatReturn.boxNineDescription")</div>
-        <div class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalAcquisitionsExVAT)</div>
-      </div>
+          <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalValueSalesExVAT)</dd>
+        </div>
+        <div class="grid-row" id="box-seven">
+          <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxSeven")</dt>
+          <dd class="column-one-half form-hint">@messages("yourVatReturn.boxSevenDescription")</dd>
+          <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalValuePurchasesExVAT)</dd>
+        </div>
+        <div class="grid-row" id="box-eight">
+          <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxEight")</dt>
+          <dd class="column-one-half form-hint">@messages("yourVatReturn.boxEightDescription")</dd>
+          <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalValueGoodsSuppliedExVAT)</dd>
+        </div>
+        <div class="grid-row" id="box-nine">
+          <dt class="column-one-quarter form-hint">@messages("yourVatReturn.boxNine")</dt>
+          <dd class="column-one-half form-hint">@messages("yourVatReturn.boxNineDescription")</dd>
+          <dd class="column-one-quarter form-hint text--right">@displayMoney(vatReturnViewModel.vatReturnDetails.vatReturn.totalAcquisitionsExVAT)</dd>
+        </div>
+      </dl>
     </section>
 
     <div class="form-group">

--- a/test/views/VatReturnDetailsViewSpec.scala
+++ b/test/views/VatReturnDetailsViewSpec.scala
@@ -61,11 +61,10 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
     val backLink = "#link-back"
 
     val gaTagElement = "#content ul"
-    val minusSymbol = "#box-four > div.column-one-quarter.form-hint.text--right > span"
-  }
+    val minusSymbol = "#box-four > dd.column-one-quarter.form-hint.text--right > span"
 
-  def boxElement(box: String, column: Int): String = {
-    s"$box > div:nth-child($column)"
+    def boxTitle(box: String): String = s"$box > dt"
+    def boxDescription(box: String): String = s"$box > dd:nth-of-type(1)"
   }
 
   val currentYear: Int = 2018
@@ -166,7 +165,7 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
 
     "have the correct box numbers in the table" in {
       val expectedBoxes = Array("Box 1", "Box 2", "Box 3", "Box 4", "Box 5", "Box 6", "Box 7", "Box 8", "Box 9")
-      expectedBoxes.indices.foreach(i => elementText(boxElement(Selectors.boxes(i), 1)) shouldBe expectedBoxes(i))
+      expectedBoxes.indices.foreach(i => elementText(Selectors.boxTitle(Selectors.boxes(i))) shouldBe expectedBoxes(i))
     }
 
     "have the correct row descriptions in the table" in {
@@ -181,7 +180,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
         "Total value of supplied goods to EC countries and related costs (excluding VAT)",
         "Total value of goods purchased from EC countries and brought into the UK, as well as any related costs (excluding VAT)"
       )
-      expectedDescriptions.indices.foreach(i => elementText(boxElement(Selectors.boxes(i), 2)) shouldBe expectedDescriptions(i))
+      expectedDescriptions.indices.foreach(i => elementText(Selectors.boxDescription(Selectors.boxes(i))) shouldBe
+        expectedDescriptions(i))
     }
 
     "have the minus symbol before the box four amount" in {
@@ -221,7 +221,8 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
 
   "Rendering the vat return details page from the returns route with flat rate scheme for an agent" should {
 
-    lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)(fakeRequestWithClientsVRN, messages, mockConfig, Lang.forCode("en"), agentUser)
+    lazy val view = views.html.returns.vatReturnDetails(vatReturnViewModel)(
+      fakeRequestWithClientsVRN, messages, mockConfig, Lang.forCode("en"), agentUser)
 
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
@@ -254,7 +255,7 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
 
     "have the correct box 6 description in the table" in {
       val expectedDescription = "Total value of sales and other supplies, excluding VAT"
-      elementText(boxElement(Selectors.boxes(5), 2)) shouldBe expectedDescription
+      elementText(Selectors.boxDescription(Selectors.boxes(5))) shouldBe expectedDescription
     }
   }
 
@@ -369,7 +370,7 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
     }
 
     "have the correct box 5 description in the table" in {
-      elementText(boxElement(Selectors.boxes(4), 2)) shouldBe "Return total"
+      elementText(Selectors.boxDescription(Selectors.boxes(4))) shouldBe "Return total"
     }
   }
 
@@ -425,7 +426,7 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
     }
 
     "have the correct box 5 description in the table" in {
-      elementText(boxElement(Selectors.boxes(4), 2)) shouldBe "Return total"
+      elementText(Selectors.boxDescription(Selectors.boxes(4))) shouldBe "Return total"
     }
   }
 
@@ -477,7 +478,7 @@ class VatReturnDetailsViewSpec extends ViewBaseSpec {
     }
 
     "have the correct box 5 description in the table" in {
-      elementText(boxElement(Selectors.boxes(4), 2)) shouldBe "Return total"
+      elementText(Selectors.boxDescription(Selectors.boxes(4))) shouldBe "Return total"
     }
   }
 


### PR DESCRIPTION
The listed changes in Github make this look quite messy but essentially the differences are:
• `<dl>` tags added below the two `<section>` tags to contain the rows within definition lists
• `<dt>` and `<dd>` tags inside each row to replace to `<div>` tags