### PR TITLE
Changed date retrieval on submitted returns controller to be eager

### DIFF
--- a/app/controllers/SubmittedReturnsController.scala
+++ b/app/controllers/SubmittedReturnsController.scala
@@ -57,7 +57,7 @@ class SubmittedReturnsController @Inject()(mcc: MessagesControllerComponents,
       Future(MovedPermanently(controllers.routes.SubmittedReturnsController.submittedReturns().url))
   }, ignoreMandatedStatus = true)
 
-  lazy val currentYear: Int = dateService.now().getYear
+  def currentYear: Int = dateService.now().getYear
 
   def submittedReturns: Action[AnyContent] = authorisedController.authorisedAction({ implicit request =>
     implicit user =>


### PR DESCRIPTION
The retrieval of the date should be a `def` so that it can be evaluated again every call. The problem with using a `val` is that if you hit the page once, then try to toggle the static date feature switch, the app itself will still be using the first date until it is reset.