### PR TITLE
BTAT-8844 Adjustment to TDM logic to call years based on ETMP date

### DIFF
--- a/app/models/MigrationDateModel.scala
+++ b/app/models/MigrationDateModel.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import java.time.LocalDate
+
+case class MigrationDateModel(migratedToETMPDate: Option[LocalDate], hybridToFullDate: Option[LocalDate])

--- a/build.sbt
+++ b/build.sbt
@@ -60,11 +60,11 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-frontend-play-26" % "3.0.0",
-  "uk.gov.hmrc" %% "govuk-template" % "5.60.0-play-26",
-  "uk.gov.hmrc" %% "play-ui" % "8.18.0-play-26",
-  "uk.gov.hmrc" %% "play-partials" % "7.0.0-play-26",
-  "uk.gov.hmrc" %% "play-language" % "4.5.0-play-26",
+  "uk.gov.hmrc" %% "bootstrap-frontend-play-26" % "3.3.0",
+  "uk.gov.hmrc" %% "govuk-template" % "5.61.0-play-26",
+  "uk.gov.hmrc" %% "play-ui" % "8.20.0-play-26",
+  "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-26",
+  "uk.gov.hmrc" %% "play-language" % "4.7.0-play-26",
   "com.typesafe.play" %% "play-json-joda" % "2.7.4"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,11 +4,11 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 

--- a/test/common/TestJson.scala
+++ b/test/common/TestJson.scala
@@ -30,7 +30,7 @@ object TestJson {
       "continueToTrade" -> true,
       "isPartialMigration" -> false,
       "customerMigratedToETMPDate" -> "2017-01-01",
-      "hybridToFullMigrationDate" -> "2017-01-01"
+      "hybridToFullMigrationDate" -> "2017-02-02"
     ),
     "ppob" -> Json.obj(
       "address" -> Json.obj(

--- a/test/common/TestModels.scala
+++ b/test/common/TestModels.scala
@@ -31,7 +31,21 @@ object TestModels {
     hasFlatRateScheme = true,
     isPartialMigration = false,
     Some("2017-01-01"),
-    Some("2017-01-01"),
+    Some("2017-02-02"),
+    mtdfb
+  )
+
+  val customerInformationMin: CustomerInformation = CustomerInformation(
+    None,
+    None,
+    None,
+    None,
+    isInsolvent = false,
+    None,
+    hasFlatRateScheme = false,
+    isPartialMigration = false,
+    None,
+    None,
     mtdfb
   )
 


### PR DESCRIPTION
The following logic tweak is to ensure that the "Previous returns" tab logic uses the new hybridToFull date, whereas the "getValidYears" function to determine API calls uses the old date (first migrated to ETMP date).